### PR TITLE
Add support for ood-portal-generator

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,10 +57,7 @@ nginx_bin: "{{ nginx_dir }}/bin/nginx"
 nginx_mime_types: "{{ nginx_dir }}/conf/mime.types"
 locations_ini: "{{ passenger_lib_dir }}/locations.ini"
 
-configure_w_ansible: true
-#
-# https://osc.github.io/ood-documentation/master/installation/cluster-config-schema.html
-# cluster:
+ood_portal_generator: false
 
 ruby_lib_dir: "/usr/lib64/ruby/"
 
@@ -75,7 +72,6 @@ rpm_repo_url: "https://yum.osc.edu/ondemand/1.6/ondemand-release-web-1.6-4.noarc
 pun_custom_env_declarations: []
 # pun_custom_env is undefined by default
 ######## END nginx_stage.yml related configs ############
-
 
 ######## START default OS related configs ############
 # OS defaults are RHEL

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -17,3 +17,18 @@
 - name: update nginx stage
   shell: "{{ ood_base_dir }}/nginx_stage/sbin/update_nginx_stage"
   become: true
+
+- name: update ood portal
+  shell: "{{ ood_base_dir }}/ood-portal-generator/sbin/update_ood_portal --force"
+  when: ood_portal_generator
+  ignore_errors: yes
+  become: true
+  notify:
+    - restart apache httpd
+    - restart httpd htcacheclean
+
+- name: restart httpd htcacheclean
+  systemd:
+    name: httpd24-htcacheclean
+    state: restarted
+  become: true

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,7 +4,6 @@
   roles:
     - role: ood-ansible
       install_from_src: false
-      apache_service_enabled: true
       _container_connection: false
       _ssh_local_connection: true
 
@@ -13,7 +12,6 @@
   roles:
     - role: ood-ansible
       install_from_src: false
-      apache_service_enabled: true
       ood_portal_generator: true
       cluster:
         v2:

--- a/molecule/default/tests/test_custom.py
+++ b/molecule/default/tests/test_custom.py
@@ -25,3 +25,8 @@ def test_cluster_is_configured(host):
 def test_nginx_min_uid(host):
     nginx_conf = '/etc/ood/config/nginx_stage.yml'
     assert host.file(nginx_conf).contains("min_uid: 500")
+
+def test_ood_portal_conf(host):
+    ood_portal_conf = '/opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf'
+    header = '# Generated using ood-portal-generator version'
+    assert host.file(ood_portal_conf).contains(header)

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -16,19 +16,6 @@ def test_httpd_running(host):
     assert len(httpd_process) > 0
 
 
-def test_ood_portal_conf(host):
-    hostname = host.check_output('hostname -s')
-    ood_portal_conf = '/opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf'
-
-    if hostname == 'custom':
-        header = '# Generated using ood-portal-generator version'
-    elif hostname == 'instance':
-        header = '# Ansible managed:'
-
-    # By default use ood-portal template
-    assert host.file(ood_portal_conf).contains(header)
-
-
 def test_httpd_running_and_enabled(host):
     httpd = host.service("httpd24-httpd")
     assert httpd.is_running

--- a/molecule/default/tests/test_instance.py
+++ b/molecule/default/tests/test_instance.py
@@ -1,0 +1,13 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('instance')
+
+
+def test_ood_portal_conf(host):
+    ood_portal_conf = '/opt/rh/httpd24/root/etc/httpd/conf.d/ood-portal.conf'
+    header = '# Ansible managed:'
+    assert host.file(ood_portal_conf).contains(header)

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,18 +9,18 @@
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
-  become: true
-  when: configure_w_ansible is defined and configure_w_ansible
   loop:
   - { src: "ood-portal.conf.j2", dest: "{{ apache_conf_dir }}/ood-portal.conf" }
-  notify:
-  - restart apache httpd
+  become: true
+  when: not ood_portal_generator
+  notify: restart apache httpd
 
 - name: template ood_portal.yml
   template:
     src: "ood_portal.yml.j2"
     dest: "{{ ood_base_conf_dir }}/ood_portal.yml"
   become: true
+  notify: update ood portal
 
 - name: template nginx_stage.yml
   template:


### PR DESCRIPTION
Apache's ood-portal.conf is currently managed exclusively by ansible
template, without the possibility of using ood-portal-generator

This commit add the update ood portal handler to generate
ood-portal.conf based on ood-portal.yml

* Add httpd htcacheclean handler
* Add ignore error com portal generation