### PR TITLE
Flip defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 ### Ansible ###
 *.retry
+*/*/pytestdebug.log
 
 ### Python ###
 # Byte-compiled / optimized / DLL files

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 script:
 - tests/check_syntax.sh
 - tests/start_containers.sh
-- tests/run_playbook.sh --tags="deps" -i tests/inventory-src
-- travis_wait 45 tests/run_playbook.sh --tags="build" -i tests/inventory-src
-- tests/run_playbook.sh --tags="install,configure" -i tests/inventory-src
-- tests/run_playbook.sh -i tests/inventory-rpm --extra-vars "@tests/extra_vars.json"
+- tests/run_playbook.sh --tags="deps" -i tests/inventory-src --extra-vars "@tests/extra_vars.json"
+- travis_wait 45 tests/run_playbook.sh --tags="build" -i tests/inventory-src --extra-vars "@tests/extra_vars.json"
+- tests/run_playbook.sh --tags="install,configure" -i tests/inventory-src --extra-vars "@tests/extra_vars.json"
+- tests/run_playbook.sh -i tests/inventory-rpm

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There is a toggle provided `install_from_src` which is by default false. When tr
 Open OnDemand source code, build it (after installing dependencies) and push the resulting build to the appropriate
 destination directories.
 
-The default behavior is is to install the rpm and configure the resulting installation and skip a lot of these tasks
+The default behavior is to install the rpm and configure the resulting installation and skip a lot of these tasks
 that build the source code.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This ansible role installs and configures [Open OnDemand](https://openondemand.o
 This role was developed for users of non RPM systems like Ubuntu, Debian or Arch because Open OnDemand does not
 currently supply packages for those platforms.
 
-There is a toggle provided `install_from_src` which is by default true. When true, this role will git pull the
+There is a toggle provided `install_from_src` which is by default false. When true, this role will git pull the
 Open OnDemand source code, build it (after installing dependencies) and push the resulting build to the appropriate
 destination directories.
 
-However, there is an RPM provided by the developers and if this flag is set to `false` this role will instead install
-the rpm and configure the resulting installation.
+The default behavior is is to install the rpm and configure the resulting installation and skip a lot of these tasks
+that build the source code.
 
 ## Getting Started
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -106,13 +106,13 @@ nginx_bin: "{{ nginx_dir }}/bin/nginx"
 nginx_mime_types: "{{ nginx_dir }}/conf/mime.types"
 locations_ini: "{{ passenger_lib_dir }}/locations.ini"
 
-ood_portal_generator: false
+ood_portal_generator: true
 
 ruby_lib_dir: "/usr/lib64/ruby/"
 
 ### install from rpm related configs
-# flip this flag to instead install from rpm
-install_from_src: true
+# flip this flag to instead install from source
+install_from_src: false
 rpm_repo_url: "https://yum.osc.edu/ondemand/1.6/ondemand-release-web-1.6-4.noarch.rpm"
 ###
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -31,4 +31,6 @@
   systemd:
     name: httpd24-htcacheclean
     state: restarted
+  # FIXME: debian could benefit from this, but would need additional installs
+  when: not install_from_src and _ssh_local_connection
   become: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -31,6 +31,6 @@
   systemd:
     name: httpd24-htcacheclean
     state: restarted
-  # FIXME: debian could benefit from this, but would need additional installs
-  when: not install_from_src and _ssh_local_connection
   become: true
+  # FIXME: debian could benefit from this, but would need additional installs
+  when: (not install_from_src) and _ssh_local_connection | bool

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -3,7 +3,7 @@
   hosts: instance
   roles:
     - role: ood-ansible
-      install_from_src: false
+      ood_portal_generator: false
       rnode_uri: "/myrnode"
       _container_connection: false
       _ssh_local_connection: true
@@ -12,8 +12,6 @@
   hosts: custom
   roles:
     - role: ood-ansible
-      install_from_src: false
-      ood_portal_generator: true
       cluster:
         v2:
           metadata:

--- a/tests/extra_vars.json
+++ b/tests/extra_vars.json
@@ -1,1 +1,1 @@
-{ "install_from_src": false }
+{ "install_from_src": true }


### PR DESCRIPTION
As we march to a 1.0 release in Galaxy, I feel like now is the time to solidify these entries as the defaults.

This was originally developed for non-RPM based systems, but I feel like that's the corner case, and indeed, automation targeting RPM based systems is the more common case and defaults should reflect that. 

Using the ood-portal-generator also gets flipped to be default.  We can keep the template, and even later allow users to specify their own, but this should likely be the default as it probably gives the best "works out of the box" experience. 