### PR TITLE
Write multiple clusters file #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,33 +99,45 @@ This is because installation directories changed from 1.6.20 to 1.7.x.
 There are a few variables in this role that enable Open OnDemand customizations
 and configuration.
 
-#### `cluster`
+#### `clusters`
 
-This configuration writes its content to `/etc/ood/config/clusters.d/<cluster_title>.yml`.
-The name of the file is extracted from `v2.metadata.title` of the configuration.
+This configuration writes its content to `/etc/ood/config/clusters.d/<cluster_key>.yml` for each cluster item on this dict.
 
 For example
 
 ```yaml
-cluster:
-  v2:
-    metadata:
-      title: my_cluster
-    login:
-      host: my_host
-    job:
-      adapter: slurm
-      bin: /usr/local
-    batch_connect:
+clusters:
+  my_cluster:
+    v2:
+      metadata:
+        title: my_cluster
+      login:
+        host: my_host
+      job:
+        adapter: slurm
+        bin: /usr/local
+      batch_connect:
+  another_cluster:
+    v2:
+      metadata:
+        title: Another Cluster
 ```
 
-Will produce `/etc/ood/config/clusters.d/my_cluster.yml` with the exact content.
+Will produce `/etc/ood/config/clusters.d/my_cluster.yml` and `/etc/ood/config/clusters.d/another_cluster.yml` with the exact content.
 
+##### my_cluster.yml
 ```yaml
 v2:
   metadata:
     title: my_cluster
   ...
+```
+
+##### another_cluster.yml
+```yaml
+v2:
+  metadata:
+    title: Another Cluster
 ```
 
 More details can be found on [Open OnDemand documentation](https://osc.github.io/ood-documentation/master/installation/add-cluster-config.html) and [Cluster Config Schema v2](https://osc.github.io/ood-documentation/master/installation/cluster-config-schema.html).

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -14,16 +14,21 @@
     - role: ood-ansible
       install_from_src: false
       ood_portal_generator: true
-      cluster:
-        v2:
-          metadata:
-            title: my_cluster
-          login:
-            host: my_host
-          job:
-            adapter: slurm
-            bin: /usr/local
-          batch_connect:
+      clusters:
+        another_cluster:
+          v2:
+            metadata:
+              title: Another Cluster
+        my_cluster:
+          v2:
+            metadata:
+              title: my_cluster
+            login:
+              host: my_host
+            job:
+              adapter: slurm
+              bin: /usr/local
+            batch_connect:
       nginx_min_uid: 500
       apache_service_enabled: true
       ood_install_apps:

--- a/molecule/default/tests/test_custom.py
+++ b/molecule/default/tests/test_custom.py
@@ -6,10 +6,10 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']
 ).get_hosts('custom')
 apps_d = "/etc/ood/config/apps"
+cluster_d = "/etc/ood/config/clusters.d"
 
 
 def test_cluster_is_configured(host):
-    cluster_d = "/etc/ood/config/clusters.d"
     cluster_yml = f"{cluster_d}/my_cluster.yml"
     assert host.file(cluster_d).is_directory
     assert host.file(cluster_yml).exists
@@ -22,6 +22,17 @@ def test_cluster_is_configured(host):
     assert host.file(cluster_yml).contains("adapter: slurm")
     assert host.file(cluster_yml).contains("bin: /usr/local")
     assert host.file(cluster_yml).contains("batch_connect:")
+
+
+def test_multiple_clusters_conf(host):
+    cluster_yml_1 = f"{cluster_d}/my_cluster.yml"
+    assert host.file(cluster_yml_1).exists
+
+    cluster_yml_2 = f"{cluster_d}/another_cluster.yml"
+    assert host.file(cluster_yml_2).exists
+    assert host.file(cluster_yml_2).contains("v2:")
+    assert host.file(cluster_yml_2).contains("metadata:")
+    assert host.file(cluster_yml_2).contains("title: Another Cluster")
 
 
 def test_nginx_min_uid(host):

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -1,9 +1,0 @@
-- name: Create clusters.d directory
-  file:
-    path: "{{ ood_base_conf_dir }}/clusters.d"
-    state: directory
-
-- name: Add cluster configuration files
-  copy:
-    content: "{{ cluster | to_nice_yaml }}"
-    dest: "{{ ood_base_conf_dir }}/clusters.d/{{ cluster['v2']['metadata']['title'] }}.yml"

--- a/tasks/clusters.yml
+++ b/tasks/clusters.yml
@@ -1,0 +1,10 @@
+- name: Create clusters.d directory
+  file:
+    path: "{{ ood_base_conf_dir }}/clusters.d"
+    state: directory
+
+- name: Add cluster configuration files
+  copy:
+    content: "{{ item.value | to_nice_yaml }}"
+    dest: "{{ ood_base_conf_dir }}/clusters.d/{{ item.key }}.yml"
+  loop: "{{ clusters | default({}) | dict2items }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,8 +30,8 @@
   become: true
   tags: [ 'configure' ]
 
-- include: cluster.yml
-  when: cluster is defined
+- include: clusters.yml
+  when: clusters is defined
   tags: [ 'configure' ]
 
 - include: install-apps.yml


### PR DESCRIPTION
Previously we could write a single cluster config file.

This commit allows users to set a dict of clusters where a cluster file
will be created for each item.