### PR TITLE
env uses double quotes to allow for bash variables

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -51,6 +51,7 @@
         dashboard:
           env:
             motd_format: markdown
+            ood_dataroot: "/mnt/newfs/$USER"
       oidc_uri: /oidc
       ood_auth_openidc:
         OIDCSessionMaxDuration: 28888

--- a/molecule/default/tests/test_custom.py
+++ b/molecule/default/tests/test_custom.py
@@ -84,14 +84,15 @@ def test_apps_file(host):
     files_d = f"{apps_d}/files"
     assert host.file(f"{files_d}").is_directory
     assert host.file(f"{files_d}/env").exists
-    assert host.file(f"{files_d}/env").contains('OOD_SHELL=/bin/bash')
+    assert host.file(f"{files_d}/env").contains('OOD_SHELL="/bin/bash"')
 
 
 def test_apps_dashboard(host):
     dashboard_d = f"{apps_d}/dashboard"
     assert host.file(f"{dashboard_d}").is_directory
     assert host.file(f"{dashboard_d}/env").exists
-    assert host.file(f"{dashboard_d}/env").contains('MOTD_FORMAT=markdown')
+    assert host.file(f"{dashboard_d}/env").contains('MOTD_FORMAT="markdown"')
+    assert host.file(f"{dashboard_d}/env").contains('OOD_DATAROOT="/mnt/newfs/$USER"')
 
 
 def test_oidc_httpd_module(host):

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,3 +1,3 @@
 {% for key, value in item.value.env.items() %}
-{{ key | upper }}={{ value | quote }}
+{{ key | upper }}="{{ value }}"
 {% endfor %}


### PR DESCRIPTION
env uses double quotes to allow for bash variables so things like `$USER` get evaluated. Single quotes don't evaluate bash variables.