### PR TITLE
Support centos8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         image:
           - 'centos:7'
+          - 'centos:8'
 
     steps:
       - name: checkout
@@ -28,7 +29,8 @@ jobs:
           python-version: 3.8
       - name: install dependencies
         run: |
-          python3 -m pip install ansible molecule molecule-docker docker testinfra
+          python3 -m pip install ansible molecule molecule-docker docker testinfra pytest-helpers-namespace
+          ansible-galaxy collection install community.general
       - name: run linter
         run: molecule lint
       - name: run tests

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -99,6 +99,9 @@ ruby_lib_dir: "/usr/lib64/ruby/"
 # flip this flag to instead install from source
 install_from_src: false
 rpm_repo_url: "https://yum.osc.edu/ondemand/1.8/ondemand-release-web-1.8-1.noarch.rpm"
+rpm_repo_key: "https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand"
+# OSC's repo rpm isn't signed
+disable_gpg_check_rpm_repo: true
 install_ondemand_dex: false
 ondemand_dex_package: ondemand-dex
 ######## END install from rpm related configs ############

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -25,4 +25,5 @@
     state: restarted
   become: true
   # FIXME: debian could benefit from this, but would need additional installs
-  when: not install_from_src
+  # even in centos:8 this is just a binary, not a systemd file
+  when: (not install_from_src) and (ansible_os_family == "RedHat" and ansible_distribution_major_version < '8')

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -15,7 +15,7 @@ ENV {{ var }} {{ value }}
 {% endif %}
 
 RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python3 sudo python3-devel python*-dnf bash iproute && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \

--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+
+pytest_plugins = ['helpers_namespace']
+
+@pytest.helpers.register
+def httpd(host):
+    if rhel_7(host):
+        return "httpd24-httpd"
+    else:
+        return "httpd"
+
+@pytest.helpers.register
+def httpd_root_dir(host):
+    if rhel_7(host):
+        return "/opt/rh/httpd24/root"
+    else:
+        return ""
+
+@pytest.helpers.register
+def httpd_log_dir(host):
+    if rhel_7(host):
+        return "/var/log/httpd24"
+    else:
+        return "/var/log/httpd"
+
+@pytest.helpers.register
+def mod_auth_openidc(host):
+    if rhel_7(host):
+        return "httpd24-mod_auth_openidc"
+    else:
+        return "mod_auth_openidc"
+
+def rhel_7(host):
+    dist = host.system_info.distribution
+    release = host.system_info.release
+    if (dist == 'redhat' or dist == 'centos') and float(release) < 8.0:
+        return True
+    else:
+        return False

--- a/molecule/default/tests/test_all.py
+++ b/molecule/default/tests/test_all.py
@@ -1,6 +1,7 @@
 import os
-
+import sys
 import testinfra.utils.ansible_runner
+import pytest
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']
@@ -17,6 +18,6 @@ def test_httpd_running(host):
 
 
 def test_httpd_running_and_enabled(host):
-    httpd = host.service("httpd24-httpd")
+    httpd = host.service(pytest.helpers.httpd(host))
     assert httpd.is_running
     assert httpd.is_enabled

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,5 +1,5 @@
 import os
-
+import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -9,12 +9,15 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_ood_portal_defaults(host):
     portal_yml = f"/etc/ood/config/ood_portal.yml"
+    httpd_root = pytest.helpers.httpd_root_dir(host)
+    log_dir = pytest.helpers.httpd_log_dir(host)
+
     assert host.file(portal_yml).exists
     assert host.file(portal_yml).contains("servername: localhost")
     assert host.file(portal_yml).contains("#proxy_server: null")
     assert host.file(portal_yml).contains("port: 80")
     assert host.file(portal_yml).contains("# Default: null (no SSL support)")
-    assert host.file(portal_yml).contains("logroot: \"/var/log/httpd24\"")
+    assert host.file(portal_yml).contains("logroot: \"{0}\"".format(log_dir))
     assert host.file(portal_yml).contains("use_rewrites: false")
     assert host.file(portal_yml).contains("use_maintenance: false")
     assert host.file(portal_yml).contains('maintenance_ip_whitelist: \\[\\]')
@@ -27,7 +30,7 @@ def test_ood_portal_defaults(host):
     assert host.file(portal_yml).contains("auth:")
     assert host.file(portal_yml).contains("- 'AuthType Basic'")
     assert host.file(portal_yml).contains("- 'AuthName \"private\"'")
-    assert host.file(portal_yml).contains("- 'AuthUserFile \"/opt/rh/httpd24/root/etc/httpd/.htpasswd\"'")
+    assert host.file(portal_yml).contains("- 'AuthUserFile \"{0}/etc/httpd/.htpasswd\"'".format(httpd_root))
     assert host.file(portal_yml).contains("- 'RequestHeader unset Authorization'")
     assert host.file(portal_yml).contains("- 'Require valid-user'")
     assert host.file(portal_yml).contains("root_uri: /pun/sys/dashboard")

--- a/tasks/deps.yml
+++ b/tasks/deps.yml
@@ -55,7 +55,7 @@
   when: ansible_os_family != 'Debian'
 
 - name: install all the gems we need
-  gem:
+  community.general.gem:
     name: "{{ item.name }}"
     version: "{{ item.version }}"
     state: present

--- a/tasks/install-rpm.yml
+++ b/tasks/install-rpm.yml
@@ -1,7 +1,13 @@
+- name: install the rpm repo's key
+  rpm_key:
+    state: present
+    key: "{{ rpm_repo_key }}"
+
 - name: install the rpm repo
   package:
     name: "{{ rpm_repo_url }}"
     state: present
+    disable_gpg_check: "{{ disable_gpg_check_rpm_repo | bool }}"
 
 - name: install additional rpms
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: include scl related overrides
   include_vars: "{{ ansible_distribution }}-scl.yml"
-  when: not install_from_src
+  when: (not install_from_src) and (ansible_os_family == "RedHat" and ansible_distribution_major_version < '8')
   tags: [ 'always' ]
 
 - include: deps.yml

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -4,3 +4,8 @@ os_dependencies:
 - libnsl
 
 apache_oidc_mod_package:  mod_auth_openidc
+
+nginx_root: "/opt/rh/ondemand/root"
+nginx_bin: "{{ nginx_root }}/sbin/nginx"
+nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
+locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"

--- a/vars/RedHat-scl.yml
+++ b/vars/RedHat-scl.yml
@@ -10,7 +10,6 @@ container_apache_restart_cmd: "{{ apache_base_dir }}/sbin/httpd-scl-wrapper -k r
 
 apache_oidc_mod_package:  httpd24-mod_auth_openidc
 
-# TODO these bits change in version 1.7.x and up.
 nginx_root: "/opt/rh/ondemand/root"
 nginx_bin: "{{ nginx_root }}/sbin/nginx"
 nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,3 +4,8 @@ os_dependencies:
 - libnsl
 
 apache_oidc_mod_package:  mod_auth_openidc
+
+nginx_root: "/opt/rh/ondemand/root"
+nginx_bin: "{{ nginx_root }}/sbin/nginx"
+nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
+locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"


### PR DESCRIPTION
Better support for centos/rhel 8. 

Along with 
- a bugfix for newer ansible versions that forces gpg checks on rpms
- refactor tests a little to have some helper functions