### PR TITLE
Remove `tag: always` from include_vars

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,9 @@
 - name: include distribution variables
   include_vars: "{{ ansible_distribution }}.yml"
-  tags: [ 'always' ]
 
 - name: include scl related overrides
   include_vars: "{{ ansible_distribution }}-scl.yml"
   when: (not install_from_src) and (ansible_os_family == "RedHat" and ansible_distribution_major_version < '8')
-  tags: [ 'always' ]
 
 - include: deps.yml
   become: true


### PR DESCRIPTION
If OOD role is defined along with other playbooks and a tag is used to
invoke non OOD related tasks, the OOD playbook will throw an error about
ansible_distribution not being defined.

This seems to be due the `tag: always` on include_vars tasks for ansible
specific distributions. This commits removes it.