### PR TITLE
Add PAM Authentication tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -175,6 +175,16 @@ httpd_port: 80
 # - "SSLCertificateKeyFile {{ ssl_cert_key }}"
 # - "SSLCertificateChainFile {{ ssl_cert_chain }}"
 
+# PAM can be used to authenticate users to OnDemand. Set it to true and
+# override httpd_auth
+ood_auth_pam: false
+# httpd_auth:
+#   - 'AuthType Basic'
+#   - 'AuthName "Open OnDemand"'
+#   - 'AuthBasicProvider PAM'
+#   - 'AuthPAMService ood'
+#   - 'Require valid-user'
+
 httpd_auth:
 - AuthType Basic
 - AuthName "private"

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -1,0 +1,8 @@
+# Setup
+
+```
+# Optionally create a new virtual environment
+# virtualenv .venv && source .venv/bin/activate
+
+pip install -r molecule/requirements.txt
+```

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -12,3 +12,10 @@
     - vars/apps.yml
     - vars/nginx.yml
     - vars/portal.yml
+
+- name: Pam auth
+  hosts: default
+  roles:
+    - role: ood-ansible
+  vars_files:
+    - vars/pam_auth.yml

--- a/molecule/default/vars/pam_auth.yml
+++ b/molecule/default/vars/pam_auth.yml
@@ -1,0 +1,1 @@
+ood_auth_pam: true

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,0 +1,6 @@
+ansible
+docker
+molecule-docker
+molecule==3.1.5
+pytest-helpers-namespace
+testinfra==5.3.1

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,3 +1,7 @@
+- name: Configure PAM auth
+  include_tasks: pam_auth.yml
+  when: ood_auth_pam|bool and ansible_os_family == "RedHat"
+
 - name: template passenger locations ini file
   template:
     src: "locations.ini.j2"

--- a/tasks/pam_auth.yml
+++ b/tasks/pam_auth.yml
@@ -1,0 +1,29 @@
+- name: Install the Apache PAM module
+  yum:
+    name: mod_authnz_pam
+    state: present
+
+- name: Copy PAM module into SCL Apache’s modules directory RHEL/CentOS 7 only
+  copy:
+    src: /usr/lib64/httpd/modules/mod_authnz_pam.so
+    dest: /opt/rh/httpd24/root/usr/lib64/httpd/modules/
+    remote_src: true
+  when: ansible_distribution_major_version == '7'
+
+- name: Enable the PAM Apache module
+  copy:
+    content: |
+      LoadModule authnz_pam_module modules/mod_authnz_pam.so
+    dest: "{{ apache_base_dir | default('')}}/etc/httpd/conf.modules.d/55-authnz_pam.conf"
+
+- name: Copy PAM module into SCL Apache’s modules directory RHEL/CentOS 7 only
+  copy:
+    src: /etc/pam.d/sshd
+    dest: /etc/pam.d/ood
+    remote_src: true
+
+- name: Allow the Apache user to read /etc/shadow
+  file:
+    path: /etc/shadow
+    mode: 0640
+    group: "{{ apache_user }}"


### PR DESCRIPTION
This commit adds a task that follows PAM Authentication documentation[1]

1. https://osc.github.io/ood-documentation/master/authentication/pam.html

I'd appreciate some help with adding tests to molecule.