### PR TITLE
ensure correct file permissions on file/folders and use same mode format

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,10 +45,12 @@ ood_core_libs:
 #     repo: https://github.com/OSC/bc_example_jupyter.git
 #     dest: {{ ood_sys_app_dir }}  # default creates
 #     version: master        # default
+#     umask: '022' # default,File=rw-r-r,Dir=rwx-rx-rx
 #   customdir: # will create /var/www/ood/apps/my/dir/customdir
 #     repo: https://github.com/OSC/bc_example_jupyter.git
 #     dest: /var/www/ood/apps/my/dir
 #     version: v1.0.1
+#     umask: '002'
 #
 ## Apps config example, default undef
 # ood_apps:

--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -2,20 +2,20 @@
   file:
     path: "{{ ood_base_conf_dir }}/apps"
     state: directory
-    mode: 'u=rwX,g=rX,o=rX'
+    mode: 'u=rwx,g=rx,o=rx'
 
 - name: Create apps directory
   file:
     path: "{{ ood_base_conf_dir }}/apps/{{ item }}"
     state: directory
-    mode: 'u=rwX,g=rX,o=rX'
+    mode: 'u=rwx,g=rx,o=rx'
   loop: "{{ ood_apps.keys() | list }}"
 
 - name: Create apps submit dir
   file:
     dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/submit"
     state: directory
-    mode: 'u=rwX,g=rX,o=rX'
+    mode: 'u=rwx,g=rx,o=rx'
   when: item.value.submit is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"
 

--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -2,17 +2,20 @@
   file:
     path: "{{ ood_base_conf_dir }}/apps"
     state: directory
+    mode: 'u=rwX,g=rX,o=rX'
 
 - name: Create apps directory
   file:
     path: "{{ ood_base_conf_dir }}/apps/{{ item }}"
     state: directory
+    mode: 'u=rwX,g=rX,o=rX'
   loop: "{{ ood_apps.keys() | list }}"
 
 - name: Create apps submit dir
   file:
     dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/submit"
     state: directory
+    mode: 'u=rwX,g=rX,o=rX'
   when: item.value.submit is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"
 
@@ -20,6 +23,7 @@
   copy:
     content: "{{ item.value.submit }}"
     dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/submit/submit.yml.erb"
+    mode: 'u=rw,g=r,o=r'
   when: item.value.submit is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"
 
@@ -27,6 +31,7 @@
   template:
     src: app.yml.j2
     dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/{{ item.value.cluster }}.yml"
+    mode: 'u=rw,g=r,o=r'
   when: item.value.cluster is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"
 
@@ -34,5 +39,6 @@
   template:
     src: env.j2
     dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/env"
+    mode: 'u=rw,g=r,o=r'
   when: item.value.env is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"

--- a/tasks/clusters.yml
+++ b/tasks/clusters.yml
@@ -1,10 +1,12 @@
 - name: Create clusters.d directory
   file:
     path: "{{ ood_base_conf_dir }}/clusters.d"
+    mode: 'u=rwX,g=rX,o=rX'
     state: directory
 
 - name: Add cluster configuration files
   copy:
     content: "{{ item.value | to_nice_yaml }}"
     dest: "{{ ood_base_conf_dir }}/clusters.d/{{ item.key }}.yml"
+    mode: 'u=rw,g=r,o=r'
   loop: "{{ clusters | default({}) | dict2items }}"

--- a/tasks/clusters.yml
+++ b/tasks/clusters.yml
@@ -1,7 +1,7 @@
 - name: Create clusters.d directory
   file:
     path: "{{ ood_base_conf_dir }}/clusters.d"
-    mode: 'u=rwX,g=rX,o=rX'
+    mode: 'u=rwx,g=rx,o=rx'
     state: directory
 
 - name: Add cluster configuration files

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -19,7 +19,7 @@
   template:
     src: "ood_portal.yml.j2"
     dest: "{{ ood_base_conf_dir }}/ood_portal.yml"
-    mode: 'u=rw,g=r,o=r'
+    mode: 'u=rw,g=r,o='
   notify: update ood portal
 
 - name: template nginx_stage.yml

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,12 +2,14 @@
   template:
     src: "locations.ini.j2"
     dest: "{{ passenger_lib_dir }}/locations.ini"
+    mode: 'u=rw,g=r,o=r'
   when: install_from_src
 
 - name: template apache file
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
+    mode: 'u=rw,g=r,o='
   loop:
   - { src: "ood-portal.conf.j2", dest: "{{ apache_conf_dir }}/ood-portal.conf" }
   when: not ood_portal_generator
@@ -17,12 +19,14 @@
   template:
     src: "ood_portal.yml.j2"
     dest: "{{ ood_base_conf_dir }}/ood_portal.yml"
+    mode: 'u=rw,g=r,o=r'
   notify: update ood portal
 
 - name: template nginx_stage.yml
   template:
     src: "nginx_stage.yml.j2"
     dest: "{{ ood_base_conf_dir }}/nginx_stage.yml"
+    mode: 'u=rw,g=r,o=r'
   notify: update nginx stage
 
 - name: enable Debian apache mods
@@ -59,7 +63,7 @@
   template:
     src: auth_openidc.conf.j2
     dest: "{{ apache_conf_dir }}/auth_openidc.conf"
-    mode: 0640
+    mode: 'u=rw,g=r,o='
     group: "{{ apache_user }}"
   when: ood_auth_openidc is defined
   notify: restart apache httpd

--- a/tasks/install-apps.yml
+++ b/tasks/install-apps.yml
@@ -3,5 +3,6 @@
     repo: "{{ item.value.repo }}"
     dest: "{{ item.value.dest | default(ood_sys_app_dir) }}/{{ item.key }}"
     version: "{{ item.value.version | default('master') }}"
+    umask: "{{ item.value.umask | default('022') }}"
   when: ood_install_apps is defined
   loop: "{{ ood_install_apps | default({}) | dict2items }}"

--- a/tasks/install-src.yml
+++ b/tasks/install-src.yml
@@ -4,7 +4,7 @@
     state: directory
     owner: root
     group: root
-    mode: '0755'
+    mode: 'u=rwX,g=rX,o=rX'
   loop:
   - "{{ ood_base_apache_dir }}"
   - "{{ ood_app_dir }}"
@@ -20,6 +20,7 @@
   file:
     path: "{{ item }}"
     state: directory
+    mode: 'u=rwX,g=rX,o=rX'
   loop: "{{ os_directories }}"
   when: os_directories is defined
 
@@ -39,7 +40,7 @@
     dest: "{{ ood_sys_app_dir }}"
     owner: root
     group: root
-    mode: '0755'
+    mode: 'u=rwX,g=rX,o=rX'
     remote_src: yes
   loop: "{{ ood_base_apps }}"
 
@@ -49,7 +50,7 @@
     dest: "{{ ood_base_dir }}"
     owner: root
     group: root
-    mode: '0755'
+    mode: 'u=rwX,g=rX,o=rX'
     remote_src: yes
   loop: "{{ ood_core_libs }}"
 
@@ -59,13 +60,14 @@
     state: touch
     owner: root
     group: root
-    mode: '0644'
+    mode: 'u=rwX,g=rX,o=rX'
   loop: "{{ ood_base_apps }}"
 
 - name: make version file
   copy:
     content: "{{ ood_source_version }}"
     dest: "{{ ood_base_dir }}/VERSION"
+    mode: 'u=rw,g=r,o=r'
 
 - name: cleanup build logfiles
   file:
@@ -77,3 +79,4 @@
   template:
     src: ood-sudoers.j2
     dest: /etc/sudoers.d/ood
+    mode: 'u=rw,g=,o='

--- a/tasks/install-src.yml
+++ b/tasks/install-src.yml
@@ -4,7 +4,7 @@
     state: directory
     owner: root
     group: root
-    mode: 'u=rwX,g=rX,o=rX'
+    mode: 'u=rwx,g=rx,o=rx'
   loop:
   - "{{ ood_base_apache_dir }}"
   - "{{ ood_app_dir }}"
@@ -20,7 +20,7 @@
   file:
     path: "{{ item }}"
     state: directory
-    mode: 'u=rwX,g=rX,o=rX'
+    mode: 'u=rwx,g=rx,o=rx'
   loop: "{{ os_directories }}"
   when: os_directories is defined
 
@@ -60,7 +60,7 @@
     state: touch
     owner: root
     group: root
-    mode: 'u=rwX,g=rX,o=rX'
+    mode: 'u=rw,g=r,o=r'
   loop: "{{ ood_base_apps }}"
 
 - name: make version file

--- a/tasks/passenger.yml
+++ b/tasks/passenger.yml
@@ -2,6 +2,7 @@
   file:
     path: "{{ item }}"
     state: directory
+    mode: 'u=rwX,g=rX,o=rX'
   become: true
   loop:
   - "{{ ood_base_dir }}"
@@ -14,6 +15,7 @@
 - name: init the passenger src directory
   file:
     path: "{{ passenger_src_dir }}"
+    mode: 'u=rwX,g=rX,o=rX'
     state: directory
 
 - name: download the passenger tars
@@ -30,6 +32,7 @@
   unarchive:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
+    mode: 'u=rwX,g=rX,o=rX'
     remote_src: yes
   become: true
   loop:
@@ -41,6 +44,7 @@
   copy:
     src: "mime.types"
     dest: "{{ nginx_dir }}/conf"
+    mode: 'u=rwX,g=rX,o=rX'
   become: true
 
 - name: symlink passenger directory and nginx binary
@@ -58,6 +62,7 @@
   file:
     path: "{{ item }}"
     state: directory
+    mode: 'u=rwX,g=rX,o=rX'
   become: true
   loop:
   - "{{ nginx_lib_dir }}"
@@ -89,7 +94,7 @@
     dest:  "{{ ruby_lib_dir }}/passenger_native_support.so"
     owner: root
     group: root
-    mode: '0755'
+    mode: 'u=rwx,g=rx,o=rx'
     remote_src: yes
   become: true
 

--- a/tasks/passenger.yml
+++ b/tasks/passenger.yml
@@ -2,7 +2,7 @@
   file:
     path: "{{ item }}"
     state: directory
-    mode: 'u=rwX,g=rX,o=rX'
+    mode: 'u=rwx,g=rx,o=rx'
   become: true
   loop:
   - "{{ ood_base_dir }}"
@@ -15,7 +15,7 @@
 - name: init the passenger src directory
   file:
     path: "{{ passenger_src_dir }}"
-    mode: 'u=rwX,g=rX,o=rX'
+    mode: 'u=rwx,g=rx,o=rx'
     state: directory
 
 - name: download the passenger tars
@@ -44,7 +44,7 @@
   copy:
     src: "mime.types"
     dest: "{{ nginx_dir }}/conf"
-    mode: 'u=rwX,g=rX,o=rX'
+    mode: 'u=rw,g=r,o=r'
   become: true
 
 - name: symlink passenger directory and nginx binary
@@ -62,7 +62,7 @@
   file:
     path: "{{ item }}"
     state: directory
-    mode: 'u=rwX,g=rX,o=rX'
+    mode: 'u=rwx,g=rx,o=rx'
   become: true
   loop:
   - "{{ nginx_lib_dir }}"


### PR DESCRIPTION
In a hardened server environment it is common to change the umask of the root user (and others) to a more restrictive setting such as '027' which remove default permissions from 'other'.  This breaks this role as many files that need to be read by other are not readable.  

To remediate I've done the following:  
- Set mode/mask any where a file/folder is copied, templated, downloaded, etc..
- Added a umask dictionary attribute to the app install from git functionality (defaults to '022')
- Reworded existing mode attributes to use the same easy to read format for permissions.


To note, when setting something to empty like 'o=' it will remove all permissions for 'o'.  Also, when using capital 'X' directories, binaries, and anything already executable will be made executable while everything else will not.
