### PR TITLE
make 1.8.19 the default build from src version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ood_source_repo: "https://github.com/OSC/ondemand.git"
-ood_source_version: "master"
+ood_source_version: "v1.8.19"
 ood_build_dir: "/tmp/ood-build"
 ood_source_dir: "{{ ood_build_dir }}/ondemand"
 


### PR DESCRIPTION
make 1.8.19 the default build from src version as it's currently building off of master which is 2.0+ and has unreleased features in it.