### PR TITLE
add namespace to galaxy metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 galaxy_info:
   role_name: open_ondemand
+  namespace: osc
   author: Jeff Ohrstrom
   company: Ohio Supercomputer Center
   description: Installs and configures Open OnDemand on various Linux distributions.


### PR DESCRIPTION
add namespace to galaxy metadata to fix warnings like

```text
 WARNING  Computed fully qualified role name of open_ondemand does not follow current galaxy requirements.
Please edit meta/main.yml and assure we can correctly determine full role name:

galaxy_info:
role_name: my_name  # if absent directory name hosting role is used instead
namespace: my_galaxy_namespace  # if absent, author is used instead
```
