### PR TITLE
default ood_source_version to working 1.8 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ There is a toggle provided `install_from_src` which is by default false. When tr
 Open OnDemand source code, build it (after installing dependencies) and push the resulting build to the appropriate
 destination directories.
 
+It's also important to note the `ood_source_version` configuration. This sets what branch or tag to pull the source
+code from. `master` maybe be unstable, while a `release_` branch is much more so. Tags like `v1.8.20` should work best.
+
 The default behavior is to install the rpm and configure the resulting installation and skip a lot of these tasks
 that build the source code.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ood_source_repo: "https://github.com/OSC/ondemand.git"
-ood_source_version: "master"
+ood_source_version: "v1.8.20"
 ood_build_dir: "/tmp/ood-build"
 ood_source_dir: "{{ ood_build_dir }}/ondemand"
 


### PR DESCRIPTION
default ood_source_version to working 1.8 tag which is currently `v1.8.20`. Also add a comment in the readme about how to change this default.