### PR TITLE
support installing specific version and from different repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,35 @@ code from. `master` maybe be unstable, while a `release_` branch is much more so
 The default behavior is to install the rpm and configure the resulting installation and skip a lot of these tasks
 that build the source code.
 
+## Installing a specific version
+
+`ondemand_package` defaults to `latest` meaning this will install the latest version on the versioned
+yum/deb repository. For example, it'll install the latest version, 2.0.20 from the versioned 2.0 yum
+repo.
+
+We use `ondemand_package` for the `name` paramter of the [ansible yum](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/yum_module.html)
+so you can speicify a specific version with `ondemand-2.0.20` or use the comparison operators
+ansible supports.
+
+### Installing from latest or nightly
+
+If you'd like to install a package from our `latest` or `nightly` repositories simply change the
+`rpm_repo_url` configuration to download the appropriate RPM. For example
+`'https://yum.osc.edu/ondemand/latest/ondemand-release-web-latest-1-6.noarch.rpm'`. **Check yum
+for the correct version of this RPM.**
+
+When installing packages from latest or nightly you may have to exclude packages depending on the
+state of project.  As an example, when developing 2.1, 2.0 RPMs on latest or nightly
+need to exclude packages.
+
+Use `ondemand_package_excludes` to specify a list of packages to exclude during the yum install.
+An example may look this when installing `2.0.20`.
+
+```yaml
+ondemand_package_excludes:
+  - 'ondemand-runtime-2.1'
+```
+
 ## Tags
 
 This role has these tags when you want to only run certain tasks.

--- a/defaults/main/install.yml
+++ b/defaults/main/install.yml
@@ -18,6 +18,8 @@ apache_log_dir: "/var/log/{{ apache_service_name }}"
 
 rpm_repo_url: "https://yum.osc.edu/ondemand/2.0/ondemand-release-web-2.0-1.noarch.rpm"
 rpm_repo_key: "https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand"
+ondemand_package: "latest"
+ondemand_package_excludes: []
 
 # OSC's repo rpm isn't signed
 disable_gpg_check_rpm_repo: true

--- a/tasks/install-rpm.yml
+++ b/tasks/install-rpm.yml
@@ -45,11 +45,20 @@
   shell: "subscription-manager repos --enable=rhel-server-rhscl-7-rpms"
   when: ansible_distribution == "Red Hat Enterprise Linux"
 
-- name: install ondemand
+- name: install latest ondemand
   yum:
     name: ondemand
-    state: latest
+    state: "{{ ondemand_package }}"
     update_cache: true
+  when: ondemand_package == "latest"
+
+- name: install specific version of ondemand
+  yum:
+    name: "{{ ondemand_package }}"
+    state: present
+    update_cache: true
+    exclude: "{{ ondemand_package_excludes | default([]) }}"
+  when: ondemand_package != "latest"
 
 - name: install ondemand-dex
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,10 +3,12 @@
   with_first_found:
     - "{{ ansible_distribution }}/{{ ansible_distribution_major_version}}.yml"
     - "{{ ansible_distribution }}.yml"
+  tags: [ 'always' ]
 
 - name: include scl related overrides
   include_vars: "{{ ansible_distribution }}-scl.yml"
   when: (not install_from_src) and (ansible_os_family == "RedHat" and ansible_distribution_major_version < '8')
+  tags: [ 'always' ]
 
 - include: deps.yml
   become: true


### PR DESCRIPTION
Fixes #130 to support installing from specific versions and from other repos.

This also has a bugfix for `always` tags on the tasks that load variables.