### PR TITLE
Support Rocky Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
         image:
           - 'centos:7'
           - 'centos:8'
+          - 'rocky:8'
         scenario:
           - 'default'
           - 'templates'

--- a/vars/Rocky.yml
+++ b/vars/Rocky.yml
@@ -1,0 +1,16 @@
+---
+os_dependencies:
+- redhat-rpm-config
+- libnsl
+
+apache_oidc_mod_package:  mod_auth_openidc
+
+nginx_root: "/opt/rh/ondemand/root"
+nginx_bin: "{{ nginx_root }}/sbin/nginx"
+nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
+locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"
+
+additional_rpm_installs:
+  - lua-posix
+  - '@ruby:2.7'
+  - '@nodejs:12'


### PR DESCRIPTION
PR supports Rocky Linux (tested on 8.5) by adding a vars file for Rocky as a direct copy of CentOS.