### PR TITLE
Added functionality to copy initializer rb-files with ansible

### DIFF
--- a/defaults/main/.apps.yml
+++ b/defaults/main/.apps.yml
@@ -45,4 +45,5 @@
 #   dashboard:
 #     env:
 #       motd_format: markdown
+#     initializers: 'files/ood/dashboard/'
 #

--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -42,3 +42,21 @@
     mode: 'u=rw,g=r,o=r'
   when: item.value.env is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"
+
+- name: Create apps initializers directory when defined
+  file:
+    path: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/initializers"
+    state: directory
+    mode: '0755'
+  when: item.value.initializers is defined
+  loop: "{{ ood_apps |  default({}) | dict2items }}"
+
+- name: Copy apps initializers when those are defined
+  copy:
+    src: "{{ item.value.initializers }}"
+    dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/initializers"
+    mode: '0644'
+    directory_mode: yes
+  when: item.value.initializers is defined
+  loop: "{{ ood_apps | default({}) | dict2items }}"
+  notify: update ood portal


### PR DESCRIPTION
Minor added functionality to use ansible to handle initializers. As these files are rb code directly my general feeling is not to template these but rather handle those separately e.g. on some local git. And Ansible would just manage the deployment of OOD services and copy these rb-files over to the server side.