### PR TITLE
fix RHEL CI and Ubuntu src installation

### DIFF
--- a/defaults/main/build.yml
+++ b/defaults/main/build.yml
@@ -4,7 +4,7 @@
 install_from_src: false
 
 ood_source_repo: "https://github.com/OSC/ondemand.git"
-ood_source_version: "v2.0.9"
+ood_source_version: "v2.0.23"
 ood_build_dir: "/tmp/ood-build"
 ood_source_dir: "{{ ood_build_dir }}/ondemand"
 ood_base_apache_dir: "/var/www/ood"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,7 @@
+- name: Prepare
+  hosts: all
+  
+  tasks:
+    - package:
+        name: ca-certificates
+        state: latest

--- a/molecule/templates/prepare.yml
+++ b/molecule/templates/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/tasks/deps.yml
+++ b/tasks/deps.yml
@@ -63,6 +63,7 @@
   loop:
   - { name: 'bundler', version: '2.1.4' }
   - { name: 'rake', version: '13.0.3' }
+  - { name: 'bcrypt', version: '3.1.17' }
 
 - name: install apache openidc mod
   package:


### PR DESCRIPTION
Ubuntu source installation needs the `bcrypt` gem and the RHEL tests are failing because of old certificates.