### PR TITLE
Potential workaround issue #54

### DIFF
--- a/defaults/main/.apps.yml
+++ b/defaults/main/.apps.yml
@@ -2,8 +2,8 @@
 # default configuration for apps, because they're site specific.
 # This file is meant to provide an example for your own variable files.
 
-## Manage cluster example, default undef
-# cluster:
+## Manage cluster files through clusters. Default undef creates no cluster files.
+# clusters:
 #   my_cluster: |
 #     ---
 #     v2:

--- a/defaults/main/.apps.yml
+++ b/defaults/main/.apps.yml
@@ -3,7 +3,8 @@
 # This file is meant to provide an example for your own variable files.
 
 ## Manage cluster example, default undef
-# cluster:
+# cluster: |
+#   ---
 #   v2:
 #     metadata:
 #       title: my_cluster
@@ -34,7 +35,8 @@
 #     cluster: my_cluster
 #     attributes:
 #       desktop: xfce
-#     submit:
+#     submit: |
+#       ---
 #       script:
 #         native:
 #           - "<%= bc_num_slots.blank? ? 1 : bc_num_slots.to_i %>"

--- a/defaults/main/.apps.yml
+++ b/defaults/main/.apps.yml
@@ -3,17 +3,18 @@
 # This file is meant to provide an example for your own variable files.
 
 ## Manage cluster example, default undef
-# cluster: |
-#   ---
-#   v2:
-#     metadata:
-#       title: my_cluster
-#     login:
-#       host: my_host
-#     job:
-#       adapter: slurm
-#       bin: /usr/local
-#     batch_connect:
+# cluster:
+#   my_cluster: |
+#     ---
+#     v2:
+#       metadata:
+#         title: my_cluster
+#       login:
+#         host: my_host
+#       job:
+#         adapter: slurm
+#         bin: /usr/local
+#       batch_connect:
 #
 ## Apps install example, default undef
 # ood_install_apps:

--- a/molecule/default/vars/apps.yml
+++ b/molecule/default/vars/apps.yml
@@ -1,18 +1,18 @@
 clusters:
-  another_cluster:
+  another_cluster: |
     v2:
-      metadata:
-        title: Another Cluster
-  my_cluster:
+        metadata:
+            title: Another Cluster
+  my_cluster: |
     v2:
-      metadata:
-        title: my_cluster
-      login:
-        host: my_host
-      job:
-        adapter: slurm
-        bin: /usr/local
-      batch_connect:
+        batch_connect: null
+        job:
+            adapter: slurm
+            bin: /usr/local
+        login:
+            host: my_host
+        metadata:
+            title: my_cluster
 
 ood_install_apps:
   jupyter:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -40,7 +40,7 @@
 
 - name: Add cluster configuration files
   copy:
-    content: "{{ item.value | to_nice_yaml }}"
+    content: "{{ item.value }}"
     dest: "{{ ood_base_conf_dir }}/clusters.d/{{ item.key }}.yml"
     mode: 'u=rw,g=r,o=r'
   loop: "{{ clusters | default({}) | dict2items }}"


### PR DESCRIPTION
This a workaround for  #54 , as the contents of the structure defined by `cluster` are only used in https://github.com/OSC/ood-ansible/blob/33feee0e93ee019a486512256bece11960aedfc0/tasks/configure.yml#L41-L47 we can just write the raw contents of the value from each defined cluster.

This method is also used in the  submit task for the apps https://github.com/OSC/ood-ansible/blob/33feee0e93ee019a486512256bece11960aedfc0/tasks/apps.yml#L22-L28