### PR TITLE
add dex_uri to ood_portal options

### DIFF
--- a/defaults/main/ood_portal.yml
+++ b/defaults/main/ood_portal.yml
@@ -119,6 +119,7 @@ oidc_settings_samefile: false
 # oidc_state_max_number_of_cookies: "10 true"
 # oidc_cookie_same_site: "On"
 # oidc_settings: {}
+# dex_uri: null
 # dex_settings: |
 #   dex:
 #     # Default based on if ssl key for ood-portal-generator is defined

--- a/molecule/default/fixtures/config/ood_portal.yml.custom.apache2
+++ b/molecule/default/fixtures/config/ood_portal.yml.custom.apache2
@@ -385,6 +385,14 @@ oidc_uri: /custom-oidc-path
 #       OIDCPassRefreshToken: On
 # Default: {} (empty hash)
 
+# The Dex URI behind Apache reverse proxy
+# Setting this value to some path will result in Dex listening on localhost
+# as well as only using HTTP for proxied communication
+# Example:
+#   dex_uri: /dex
+# Default: null
+#dex_uri: null
+
 # Dex configurations, values inside the "dex" structure are directly used to configure Dex
 # If the value for "dex" key is false or null, Dex support is disabled
 # Dex support will auto-enable if ondemand-dex package is installed

--- a/molecule/default/fixtures/config/ood_portal.yml.custom.httpd
+++ b/molecule/default/fixtures/config/ood_portal.yml.custom.httpd
@@ -385,6 +385,14 @@ oidc_uri: /custom-oidc-path
 #       OIDCPassRefreshToken: On
 # Default: {} (empty hash)
 
+# The Dex URI behind Apache reverse proxy
+# Setting this value to some path will result in Dex listening on localhost
+# as well as only using HTTP for proxied communication
+# Example:
+#   dex_uri: /dex
+# Default: null
+#dex_uri: null
+
 # Dex configurations, values inside the "dex" structure are directly used to configure Dex
 # If the value for "dex" key is false or null, Dex support is disabled
 # Dex support will auto-enable if ondemand-dex package is installed

--- a/molecule/default/fixtures/config/ood_portal.yml.custom.httpd24-httpd
+++ b/molecule/default/fixtures/config/ood_portal.yml.custom.httpd24-httpd
@@ -385,6 +385,14 @@ oidc_uri: /custom-oidc-path
 #       OIDCPassRefreshToken: On
 # Default: {} (empty hash)
 
+# The Dex URI behind Apache reverse proxy
+# Setting this value to some path will result in Dex listening on localhost
+# as well as only using HTTP for proxied communication
+# Example:
+#   dex_uri: /dex
+# Default: null
+#dex_uri: null
+
 # Dex configurations, values inside the "dex" structure are directly used to configure Dex
 # If the value for "dex" key is false or null, Dex support is disabled
 # Dex support will auto-enable if ondemand-dex package is installed

--- a/molecule/default/fixtures/config/ood_portal.yml.default.apache2
+++ b/molecule/default/fixtures/config/ood_portal.yml.default.apache2
@@ -384,6 +384,14 @@ pun_max_retries: 5
 #       OIDCPassRefreshToken: On
 # Default: {} (empty hash)
 
+# The Dex URI behind Apache reverse proxy
+# Setting this value to some path will result in Dex listening on localhost
+# as well as only using HTTP for proxied communication
+# Example:
+#   dex_uri: /dex
+# Default: null
+#dex_uri: null
+
 # Dex configurations, values inside the "dex" structure are directly used to configure Dex
 # If the value for "dex" key is false or null, Dex support is disabled
 # Dex support will auto-enable if ondemand-dex package is installed

--- a/molecule/default/fixtures/config/ood_portal.yml.default.httpd
+++ b/molecule/default/fixtures/config/ood_portal.yml.default.httpd
@@ -384,6 +384,14 @@ pun_max_retries: 5
 #       OIDCPassRefreshToken: On
 # Default: {} (empty hash)
 
+# The Dex URI behind Apache reverse proxy
+# Setting this value to some path will result in Dex listening on localhost
+# as well as only using HTTP for proxied communication
+# Example:
+#   dex_uri: /dex
+# Default: null
+#dex_uri: null
+
 # Dex configurations, values inside the "dex" structure are directly used to configure Dex
 # If the value for "dex" key is false or null, Dex support is disabled
 # Dex support will auto-enable if ondemand-dex package is installed

--- a/molecule/default/fixtures/config/ood_portal.yml.default.httpd24-httpd
+++ b/molecule/default/fixtures/config/ood_portal.yml.default.httpd24-httpd
@@ -384,6 +384,14 @@ pun_max_retries: 5
 #       OIDCPassRefreshToken: On
 # Default: {} (empty hash)
 
+# The Dex URI behind Apache reverse proxy
+# Setting this value to some path will result in Dex listening on localhost
+# as well as only using HTTP for proxied communication
+# Example:
+#   dex_uri: /dex
+# Default: null
+#dex_uri: null
+
 # Dex configurations, values inside the "dex" structure are directly used to configure Dex
 # If the value for "dex" key is false or null, Dex support is disabled
 # Dex support will auto-enable if ondemand-dex package is installed

--- a/molecule/default/fixtures/config/ood_portal.yml.oidc.apache2
+++ b/molecule/default/fixtures/config/ood_portal.yml.oidc.apache2
@@ -388,6 +388,14 @@ oidc_settings:
   OIDCCryptoPassphrase: 'mycryptopass'
   OIDCPassRefreshToken: 'On'
 
+# The Dex URI behind Apache reverse proxy
+# Setting this value to some path will result in Dex listening on localhost
+# as well as only using HTTP for proxied communication
+# Example:
+#   dex_uri: /dex
+# Default: null
+#dex_uri: null
+
 # Dex configurations, values inside the "dex" structure are directly used to configure Dex
 # If the value for "dex" key is false or null, Dex support is disabled
 # Dex support will auto-enable if ondemand-dex package is installed

--- a/molecule/default/fixtures/config/ood_portal.yml.oidc.httpd
+++ b/molecule/default/fixtures/config/ood_portal.yml.oidc.httpd
@@ -388,6 +388,14 @@ oidc_settings:
   OIDCCryptoPassphrase: 'mycryptopass'
   OIDCPassRefreshToken: 'On'
 
+# The Dex URI behind Apache reverse proxy
+# Setting this value to some path will result in Dex listening on localhost
+# as well as only using HTTP for proxied communication
+# Example:
+#   dex_uri: /dex
+# Default: null
+#dex_uri: null
+
 # Dex configurations, values inside the "dex" structure are directly used to configure Dex
 # If the value for "dex" key is false or null, Dex support is disabled
 # Dex support will auto-enable if ondemand-dex package is installed

--- a/molecule/default/fixtures/config/ood_portal.yml.oidc.httpd24-httpd
+++ b/molecule/default/fixtures/config/ood_portal.yml.oidc.httpd24-httpd
@@ -388,6 +388,14 @@ oidc_settings:
   OIDCCryptoPassphrase: 'mycryptopass'
   OIDCPassRefreshToken: 'On'
 
+# The Dex URI behind Apache reverse proxy
+# Setting this value to some path will result in Dex listening on localhost
+# as well as only using HTTP for proxied communication
+# Example:
+#   dex_uri: /dex
+# Default: null
+#dex_uri: null
+
 # Dex configurations, values inside the "dex" structure are directly used to configure Dex
 # If the value for "dex" key is false or null, Dex support is disabled
 # Dex support will auto-enable if ondemand-dex package is installed

--- a/molecule/src-build/fixtures/config/ood_portal.yml.apache2
+++ b/molecule/src-build/fixtures/config/ood_portal.yml.apache2
@@ -384,6 +384,14 @@ pun_max_retries: 5
 #       OIDCPassRefreshToken: On
 # Default: {} (empty hash)
 
+# The Dex URI behind Apache reverse proxy
+# Setting this value to some path will result in Dex listening on localhost
+# as well as only using HTTP for proxied communication
+# Example:
+#   dex_uri: /dex
+# Default: null
+#dex_uri: null
+
 # Dex configurations, values inside the "dex" structure are directly used to configure Dex
 # If the value for "dex" key is false or null, Dex support is disabled
 # Dex support will auto-enable if ondemand-dex package is installed

--- a/templates/ood_portal.yml.j2
+++ b/templates/ood_portal.yml.j2
@@ -468,6 +468,16 @@ oidc_settings:
 {% endfor %}
 {% endif %}
 
+# The Dex URI behind Apache reverse proxy
+# Setting this value to some path will result in Dex listening on localhost
+# as well as only using HTTP for proxied communication
+# Example:
+#   dex_uri: /dex
+# Default: null
+{% if dex_uri is defined %}dex_uri: '{{ dex_uri }}'
+{% else %}#dex_uri: null
+{% endif %}
+
 # Dex configurations, values inside the "dex" structure are directly used to configure Dex
 # If the value for "dex" key is false or null, Dex support is disabled
 # Dex support will auto-enable if ondemand-dex package is installed


### PR DESCRIPTION
Fixes #161 by adding `dex_uri` to ood_portal options.