### PR TITLE
Add var apache_service_state

### DIFF
--- a/defaults/main/install.yml
+++ b/defaults/main/install.yml
@@ -9,6 +9,7 @@ ood_usr_app_dir: "{{ ood_app_dir }}/usr"
 
 # OS defaults are RHEL-like systems
 apache_service_enabled: true
+apache_service_state: started
 apache_package_name: httpd
 apache_service_name: httpd
 apache_user: apache

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: restart apache httpd
   systemd:
     name: "{{ apache_service_name }}"
-    state: restarted
+    state: "{{ 'restarted' if 'started' in apache_service_state else omit }}" # effectively makes handler conditional on state=[re]started
     enabled: "{{ apache_service_enabled }}"
   become: true
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -103,5 +103,5 @@
 - name: start apache service
   systemd:
     name: "{{ apache_service_name }}"
-    state: started
+    state: "{{ apache_service_state }}"
     enabled: "{{ apache_service_enabled }}"


### PR DESCRIPTION
Sometimes its useful to run this role without actually starting apache (e.g. for image build). Adds `apache_service_state` following the pattern for `apache_service_enabled`.