### PR TITLE
Handle releasever having a minor version

### DIFF
--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -21,6 +21,15 @@
     disable_gpg_check: "{{ disable_gpg_check_rpm_repo | bool }}"
   when: ansible_os_family == "RedHat"
 
+- name: Remove minor releasever from repofiles
+  ansible.builtin.replace:
+    path: /etc/yum.repos.d/ondemand-web.repo
+    regexp: '\$releasever'
+    replace: "{{ releasever | split('.') | first }}"
+  when:
+    - ansible_os_family == "RedHat"
+    - (releasever is defined) and ('.' in releasever)
+
 - name: install the apt repo
   apt:
     deb: "{{ apt_repo_url }}"


### PR DESCRIPTION
Slurm appliance needs to set yum's `$releasever` to avoid getting RL8.7 packages. The repofile installed by `ondemand-release-web-2.0-1.noarch.rpm` looks like this, but actually the repo URLs only have major versions:


```
[rocky@demo-login-0 ~]$ cat /etc/yum.repos.d/ondemand-web.repo 
[ondemand-web]
name=Open OnDemand Web Repo
baseurl=https://yum.osc.edu/ondemand/2.0/web/el$releasever/$basearch/
enabled=1
gpgcheck=1
repo_gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ondemand

[ondemand-web-source]
name=Open OnDemand Web Repo
baseurl=https://yum.osc.edu/ondemand/2.0/web/el$releasever/SRPMS/
enabled=0
gpgcheck=1
repo_gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ondemand
```