### PR TITLE
fix linting errors and enable ansible-lint

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -1,0 +1,3 @@
+# Ansible-lint completely ignores rules or tags listed below
+skip_list:
+  - package-latest

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,28 +1,28 @@
 ---
-- name: restart apache httpd
-  systemd:
+- name: Restart apache httpd
+  ansible.builtin.systemd:
     name: "{{ apache_service_name }}"
     state: "{{ 'restarted' if 'started' in apache_service_state else omit }}" # effectively makes handler conditional on state=[re]started
     enabled: "{{ apache_service_enabled }}"
   become: true
 
-- name: update nginx stage
-  shell: "{{ ood_base_dir }}/nginx_stage/sbin/update_nginx_stage"
+- name: Update nginx stage
+  ansible.builtin.command: "{{ ood_base_dir }}/nginx_stage/sbin/update_nginx_stage"
   become: true
 
-- name: update ood portal
-  shell: "{{ ood_base_dir }}/ood-portal-generator/sbin/update_ood_portal --force"
+- name: Update ood portal
+  ansible.builtin.command: "{{ ood_base_dir }}/ood-portal-generator/sbin/update_ood_portal --force"
   when: ood_portal_generator
   ignore_errors: yes
   become: true
   environment:
     APACHE: "{{ apache_conf_dir }}/ood-portal.conf"
   notify:
-    - restart apache httpd
-    - restart httpd htcacheclean
+    - Restart apache httpd
+    - Restart httpd htcacheclean
 
-- name: restart httpd htcacheclean
-  systemd:
+- name: Restart httpd htcacheclean
+  ansible.builtin.systemd:
     name: httpd24-htcacheclean
     state: restarted
   become: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,18 +5,15 @@ galaxy_info:
   company: Ohio Supercomputer Center
   description: Installs and configures Open OnDemand on various Linux distributions.
   license: MIT
-  min_ansible_version: 2.0
+  min_ansible_version: '2.0'
   platforms:
     - name: Debian
       versions:
         - buster
     - name: EL
       versions:
-        - 7
-        - 8
-    - name: Fedora
-      versions:
-        - 30
+        - '7'
+        - '8'
     - name: Ubuntu
       versions:
         - bionic
@@ -26,6 +23,3 @@ galaxy_info:
     - supercomputing
     - gateway
     - portal
-
-  dependencies:
-    - community.general.gem

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - community.general

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ driver:
 lint: |
   set -e
   yamllint .
-  ansible-lint || true
+  ansible-lint
 
 platforms:
   - name: default

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -2,11 +2,13 @@
   hosts: all
   
   tasks:
-    - apt:
+    - name: Apt update
+      ansible.builtin.apt:
         update_cache: yes
       when: ansible_os_family == "Debian"
 
-    - package:
+    - name: Install extra packages
+      ansible.builtin.package:
         name: "{{ item }}"
         state: latest
       loop:

--- a/molecule/default/tasks/verify_custom.yml
+++ b/molecule/default/tasks/verify_custom.yml
@@ -1,7 +1,8 @@
-- name: copy custom cluster files to container
-  copy:
+- name: Copy custom cluster files to container
+  ansible.builtin.copy:
     src: "{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"
+    mode: 'u=rw,g=r,o=r'
   with_items:
     - { src: "fixtures/clusters.d/my_cluster.yml", dest: "my_cluster.yml" }
     - { src: "fixtures/clusters.d/another_cluster.yml", dest: "another_cluster.yml" }
@@ -11,8 +12,8 @@
     - { src: "fixtures/config/auth_openidc.conf", dest: "auth_openidc.conf" }
     - { src: "fixtures/ondemand.d/ondemand.yml", dest: "ondemand.yml" }
 
-- name: verify config files
-  shell: "diff /tmp/{{ item.left }} {{ item.right }}"
+- name: Verify config files
+  ansible.builtin.command: "diff /tmp/{{ item.left }} {{ item.right }}"
   with_items:
     - { left: "dashboard.env", right: "{{ ood_base_conf_dir }}/apps/dashboard/env" }
     - { left: "files.env", right: "{{ ood_base_conf_dir }}/apps/files/env" }
@@ -22,8 +23,9 @@
     - { left: "bc_desktop/submit/submit.yml.erb", right: "{{ ood_base_conf_dir }}/apps/bc_desktop/submit/submit.yml.erb" }
     - { left: "auth_openidc.conf", right: "{{ apache_conf_dir }}/auth_openidc.conf" }
     - { left: "ondemand.yml", right: "{{ ood_base_conf_dir }}/ondemand.d/ondemand.yml" }
+  changed_when: false
 
-- name: verify sys/jupyter was installed correctly
+- name: Verify sys/jupyter was installed correctly
   ansible.builtin.git:
     repo: 'https://github.com/OSC/bc_example_jupyter.git'
     dest: '/var/www/ood/apps/sys/jupyter'
@@ -31,7 +33,7 @@
     update: no
     version: master
 
-- name: verify dev/customdir app was installed correctly
+- name: Verify dev/customdir app was installed correctly
   ansible.builtin.git:
     repo: 'https://github.com/OSC/bc_example_jupyter.git'
     dest: '/var/www/ood/apps/dev/customdir'

--- a/molecule/default/tasks/verify_default.yml
+++ b/molecule/default/tasks/verify_default.yml
@@ -3,4 +3,6 @@
     if [[ -n $(grep '[^[:space:]]' /etc/ood/config/ondemand.d/ondemand.yml) ]]; then 
       false
     fi
+  args:
+    executable: /bin/bash
   changed_when: false

--- a/molecule/default/tasks/verify_default.yml
+++ b/molecule/default/tasks/verify_default.yml
@@ -1,3 +1,4 @@
-- name: verify ondemand.d/ondemand.yml file is empty
-  shell: |
+- name: Verify ondemand.d/ondemand.yml file is empty
+  ansible.builtin.command: |
     if [[ -n $(grep '[^[:space:]]' /etc/ood/config/ondemand.d/ondemand.yml) ]]; then false; fi
+  changed_when: false

--- a/molecule/default/tasks/verify_default.yml
+++ b/molecule/default/tasks/verify_default.yml
@@ -1,4 +1,6 @@
 - name: Verify ondemand.d/ondemand.yml file is empty
-  ansible.builtin.command: |
-    if [[ -n $(grep '[^[:space:]]' /etc/ood/config/ondemand.d/ondemand.yml) ]]; then false; fi
+  ansible.builtin.shell: |
+    if [[ -n $(grep '[^[:space:]]' /etc/ood/config/ondemand.d/ondemand.yml) ]]; then 
+      false
+    fi
   changed_when: false

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,56 +1,60 @@
-- name: verify
+- name: Verify
   hosts: all
 
   tasks:
-  - name: include defaults
-    include_vars:
+  - name: Include defaults
+    ansible.builtin.include_vars:
       dir: ../../defaults/main
 
-  - name: include distribution variables
-    include_vars: "{{ item }}"
+  - name: Include distribution variables
+    ansible.builtin.include_vars: "{{ item }}"
     with_first_found:
-      - "../../vars/{{ ansible_distribution }}/{{ ansible_distribution_major_version}}.yml"
+      - "../../vars/{{ ansible_distribution }}/{{ ansible_distribution_major_version }}.yml"
       - "../../vars/{{ ansible_distribution }}.yml"
 
-  - name: include scl related overrides
-    include_vars: "../../vars/{{ ansible_distribution }}-scl.yml"
+  - name: Include scl related overrides
+    ansible.builtin.include_vars: "../../vars/{{ ansible_distribution }}-scl.yml"
     when: (not install_from_src) and (ansible_os_family == "RedHat" and ansible_distribution_major_version < '8')
 
-  - name: get the package facts
+  - name: Get the package facts
     ansible.builtin.package_facts:
       manager: auto
   
-  - name: ensure ondemand package is installed
-    fail:
+  - name: Ensure ondemand package is installed
+    ansible.builtin.fail:
       msg: ondemand package was not installed.
     when: "'ondemand' not in ansible_facts.packages"
 
-  - name: ensure {{ apache_service_name }} is running
+  - name: Ensure httpd is running
     ansible.builtin.systemd:
       state: started
       name: "{{ apache_service_name }}"
 
-  - name: copy fixture files to container
-    copy:
+  - name: Copy fixture files to container
+    ansible.builtin.copy:
       src: "{{ item.src }}"
       dest: "/tmp/{{ item.dest }}"
+      mode: 'u=rw,g=r,o=r'
     with_items:
       - { src: "fixtures/config/ood_portal.yml.{{ inventory_hostname }}.{{ apache_service_name }}", dest: "ood_portal.yml" }
       - { src: "fixtures/config/nginx_stage.yml.{{ inventory_hostname }}.{{ ansible_os_family }}", dest: "nginx_stage.yml" }
 
-  - name: verify the config files
-    shell: "diff /tmp/{{ item }} /etc/ood/config/{{ item }}"
+  - name: Verify the config files
+    ansible.builtin.command: "diff /tmp/{{ item }} /etc/ood/config/{{ item }}"
     with_items:
       - "nginx_stage.yml"
       - "ood_portal.yml"
+    changed_when: false
 
-  - name: make sure ood portal exists
-    file:
+  - name: Make sure ood portal exists
+    ansible.builtin.file:
       path: "{{ apache_conf_dir }}/ood-portal.conf"
       state: file
 
-  - include: tasks/verify_custom.yml
+  - name: Verify Custom
+    ansible.builtin.include_tasks: tasks/verify_custom.yml
     when: inventory_hostname == "custom"
 
-  - include: tasks/verify_default.yml
+  - name: Verify Default
+    ansible.builtin.include_tasks: tasks/verify_default.yml
     when: inventory_hostname == "default"

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -8,7 +8,7 @@ driver:
 lint: |
   set -e
   yamllint .
-  ansible-lint || true
+  ansible-lint
 
 platforms:
   - name: default

--- a/molecule/upgrade/prepare.yml
+++ b/molecule/upgrade/prepare.yml
@@ -2,11 +2,13 @@
   hosts: all
   
   tasks:
-    - apt:
+    - name: Update apt cache
+      ansible.builtin.apt:
         update_cache: yes
       when: ansible_os_family == "Debian"
 
-    - package:
+    - name: Install missing packages
+      ansible.builtin.package:
         name: "{{ item }}"
         state: latest
       loop:

--- a/molecule/upgrade/verify.yml
+++ b/molecule/upgrade/verify.yml
@@ -66,4 +66,6 @@
         source /opt/ood/ondemand/enable
       fi
       node --version | grep v14
+    args:
+      executable: /bin/bash
     changed_when: false

--- a/molecule/upgrade/verify.yml
+++ b/molecule/upgrade/verify.yml
@@ -62,5 +62,8 @@
   - name: Verify node version
     ansible.builtin.shell: |
       set -o pipefail
-      if [ -f /opt/ood/ondemand/enable ]; then source /opt/ood/ondemand/enable; fi; node --version | grep v14
+      if [ -f /opt/ood/ondemand/enable ]; then 
+        source /opt/ood/ondemand/enable
+      fi
+      node --version | grep v14
     changed_when: false

--- a/molecule/upgrade/verify.yml
+++ b/molecule/upgrade/verify.yml
@@ -1,59 +1,66 @@
-- name: verify
+- name: Verify
   hosts: all
 
   tasks:
-  - name: include defaults
-    include_vars:
+  - name: Include defaults
+    ansible.builtin.include_vars:
       dir: ../../defaults/main
 
-  - name: include distribution variables
-    include_vars: "{{ item }}"
+  - name: Include distribution variables
+    ansible.builtin.include_vars: "{{ item }}"
     with_first_found:
-      - "../../vars/{{ ansible_distribution }}/{{ ansible_distribution_major_version}}.yml"
+      - "../../vars/{{ ansible_distribution }}/{{ ansible_distribution_major_version }}.yml"
       - "../../vars/{{ ansible_distribution }}.yml"
 
-  - name: include scl related overrides
-    include_vars: "../../vars/{{ ansible_distribution }}-scl.yml"
+  - name: Include scl related overrides
+    ansible.builtin.include_vars: "../../vars/{{ ansible_distribution }}-scl.yml"
     when: (not install_from_src) and (ansible_os_family == "RedHat" and ansible_distribution_major_version < '8')
 
-  - name: get the package facts
+  - name: Get the package facts
     ansible.builtin.package_facts:
       manager: auto
   
-  - name: ensure ondemand package is installed
-    fail:
+  - name: Ensure ondemand package is installed
+    ansible.builtin.fail:
       msg: ondemand package was not installed.
     when: "'ondemand' not in ansible_facts.packages"
 
-  - name: ensure {{ apache_service_name }} is running
+  - name: Ensure httpd is running
     ansible.builtin.systemd:
       state: started
       name: "{{ apache_service_name }}"
 
-  - name: copy fixture files to container
-    copy:
+  - name: Copy fixture files to container
+    ansible.builtin.copy:
       src: "{{ item.src }}"
       dest: "/tmp/{{ item.dest }}"
+      mode: 'u=rw,g=r,o=r'
     with_items:
       - { src: "fixtures/config/ood_portal.yml.{{ inventory_hostname }}.{{ apache_service_name }}", dest: "ood_portal.yml" }
       - { src: "fixtures/config/nginx_stage.yml.{{ inventory_hostname }}.{{ ansible_os_family }}", dest: "nginx_stage.yml" }
 
-  - name: verify the config files
-    shell: "diff /tmp/{{ item }} /etc/ood/config/{{ item }}"
+  - name: Verify the config files
+    ansible.builtin.command: "diff /tmp/{{ item }} /etc/ood/config/{{ item }}"
     with_items:
       - "nginx_stage.yml"
       - "ood_portal.yml"
+    changed_when: false
 
-  - name: make sure ood portal exists
-    file:
+  - name: Make sure ood portal exists
+    ansible.builtin.file:
       path: "{{ apache_conf_dir }}/ood-portal.conf"
       state: file
 
-  - include: tasks/verify_custom.yml
+  - name: Include verify custom tasks
+    ansible.builtin.include_tasks: tasks/verify_custom.yml
     when: inventory_hostname == "custom"
 
-  - include: tasks/verify_default.yml
+  - name: Include verity default tasks
+    ansible.builtin.include_tasks: tasks/verify_default.yml
     when: inventory_hostname == "default"
   
   - name: Verify node version
-    shell: if [ -f /opt/ood/ondemand/enable ]; then source /opt/ood/ondemand/enable; fi; node --version | grep v14
+    ansible.builtin.shell: |
+      set -o pipefail
+      if [ -f /opt/ood/ondemand/enable ]; then source /opt/ood/ondemand/enable; fi; node --version | grep v14
+    changed_when: false

--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -1,18 +1,18 @@
 - name: Create apps base directory
-  file:
+  ansible.builtin.file:
     path: "{{ ood_base_conf_dir }}/apps"
     state: directory
     mode: 'u=rwx,g=rx,o=rx'
 
 - name: Create apps directory
-  file:
+  ansible.builtin.file:
     path: "{{ ood_base_conf_dir }}/apps/{{ item }}"
     state: directory
     mode: 'u=rwx,g=rx,o=rx'
   loop: "{{ ood_apps.keys() | list }}"
 
 - name: Create apps submit dir
-  file:
+  ansible.builtin.file:
     dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/submit"
     state: directory
     mode: 'u=rwx,g=rx,o=rx'
@@ -20,7 +20,7 @@
   loop: "{{ ood_apps | default({}) | dict2items }}"
 
 - name: Create apps submit template/file
-  copy:
+  ansible.builtin.copy:
     content: "{{ item.value.submit }}"
     dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/submit/submit.yml.erb"
     mode: 'u=rw,g=r,o=r'
@@ -28,7 +28,7 @@
   loop: "{{ ood_apps | default({}) | dict2items }}"
 
 - name: Create apps yml file with cluster name
-  template:
+  ansible.builtin.template:
     src: app.yml.j2
     dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/{{ item.value.cluster }}.yml"
     mode: 'u=rw,g=r,o=r'
@@ -36,7 +36,7 @@
   loop: "{{ ood_apps | default({}) | dict2items }}"
 
 - name: Create apps env file
-  template:
+  ansible.builtin.template:
     src: env.j2
     dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/env"
     mode: 'u=rw,g=r,o=r'
@@ -44,15 +44,15 @@
   loop: "{{ ood_apps | default({}) | dict2items }}"
 
 - name: Create apps initializers directory when defined
-  file:
+  ansible.builtin.file:
     path: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/initializers"
     state: directory
     mode: '0755'
   when: item.value.initializers is defined
-  loop: "{{ ood_apps |  default({}) | dict2items }}"
+  loop: "{{ ood_apps | default({}) | dict2items }}"
 
 - name: Copy apps initializers when those are defined
-  copy:
+  ansible.builtin.copy:
     src: "{{ item.value.initializers }}"
     dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/initializers"
     mode: '0644'

--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -59,4 +59,4 @@
     directory_mode: yes
   when: item.value.initializers is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"
-  notify: update ood portal
+  notify: Update ood portal

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,23 +1,26 @@
-- name: make a tmp staging directory
-  file:
+- name: Make a tmp staging directory
+  ansible.builtin.file:
     path: "{{ ood_source_dir }}"
     state: directory
+    mode: 'u=rwx,g=rx,o=rx'
 
-- name: get the source code
-  git:
+- name: Get the source code
+  ansible.builtin.git:
     repo: "{{ ood_source_repo }}"
     dest: "{{ ood_source_dir }}"
     version: "{{ ood_source_version }}"
     force: yes
 
-- name: clean up to ensure proper build
-  shell: rake clean
+- name: Clean up to ensure proper build
+  ansible.builtin.command: rake clean
   args:
     chdir: "{{ ood_source_dir }}"
+  changed_when: true
 
-- name: build the project (this will take some time)
-  shell: "rake build -mj$(nproc) > build.out 2>&1"
+- name: Build the project (this will take some time)
+  ansible.builtin.command: "rake build -mj$(nproc) > build.out 2>&1"
   args:
     chdir: "{{ ood_source_dir }}"
   poll: 30
   async: 1200
+  changed_when: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -20,14 +20,14 @@
     src: "ood_portal.yml.j2"
     dest: "{{ ood_base_conf_dir }}/ood_portal.yml"
     mode: 'u=rw,g=r,o='
-  notify: update ood portal
+  notify: Update ood portal
 
 - name: Template nginx_stage.yml
   ansible.builtin.template:
     src: "nginx_stage.yml.j2"
     dest: "{{ ood_base_conf_dir }}/nginx_stage.yml"
     mode: 'u=rw,g=r,o=r'
-  notify: update nginx stage
+  notify: Update nginx stage
 
 - name: Make .d configuration directories
   ansible.builtin.file:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,36 +1,36 @@
-- name: template passenger locations ini file
-  template:
+- name: Template passenger locations ini file
+  ansible.builtin.template:
     src: "locations.ini.j2"
     dest: "{{ passenger_lib_dir }}/locations.ini"
     mode: 'u=rw,g=r,o=r'
   when: install_from_src
 
-- name: template apache file
-  template:
+- name: Template apache file
+  ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     mode: 'u=rw,g=r,o='
   loop:
   - { src: "ood-portal.conf.j2", dest: "{{ apache_conf_dir }}/ood-portal.conf" }
   when: not ood_portal_generator
-  notify: restart apache httpd
+  notify: Restart apache httpd
 
-- name: template ood_portal.yml
-  template:
+- name: Template ood_portal.yml
+  ansible.builtin.template:
     src: "ood_portal.yml.j2"
     dest: "{{ ood_base_conf_dir }}/ood_portal.yml"
     mode: 'u=rw,g=r,o='
   notify: update ood portal
 
-- name: template nginx_stage.yml
-  template:
+- name: Template nginx_stage.yml
+  ansible.builtin.template:
     src: "nginx_stage.yml.j2"
     dest: "{{ ood_base_conf_dir }}/nginx_stage.yml"
     mode: 'u=rw,g=r,o=r'
   notify: update nginx stage
 
-- name: make .d configuration directories
-  file:
+- name: Make .d configuration directories
+  ansible.builtin.file:
     path: "{{ item }}"
     mode: 'u=rwx,g=rx,o=rx'
     state: directory
@@ -39,21 +39,21 @@
     - "{{ ood_base_conf_dir }}/ondemand.d"
 
 - name: Add cluster configuration files
-  copy:
+  ansible.builtin.copy:
     content: "{{ item.value | to_nice_yaml }}"
     dest: "{{ ood_base_conf_dir }}/clusters.d/{{ item.key }}.yml"
     mode: 'u=rw,g=r,o=r'
   loop: "{{ clusters | default({}) | dict2items }}"
   when: clusters is defined
 
-- name: template ondemand.yml
-  template:
+- name: Template ondemand.yml
+  ansible.builtin.template:
     src: "ondemand.yml.j2"
     dest: "{{ ood_base_conf_dir }}/ondemand.d/ondemand.yml"
     mode: 'u=rw,g=r,o=r'
 
-- name: enable Debian apache mods
-  file:
+- name: Enable Debian apache mods
+  ansible.builtin.file:
     src: "{{ apache_etc_dir }}/mods-available/{{ item }}.load"
     dest: "{{ apache_etc_dir }}/mods-enabled/{{ item }}.load"
     state: link
@@ -65,15 +65,15 @@
   - proxy
   - proxy_http
 
-- name: enable Debian ssl mod
-  file:
+- name: Enable Debian ssl mod
+  ansible.builtin.file:
     src: "{{ apache_etc_dir }}/mods-available/ssl.load"
     dest: "{{ apache_etc_dir }}/mods-enabled/ssl.load"
     state: link
   when: ansible_os_family == "Debian" and ssl is defined
 
-- name: enable Debian oidc mod
-  file:
+- name: Enable Debian oidc mod
+  ansible.builtin.file:
     src: "{{ apache_etc_dir }}/mods-available/auth_openidc.load"
     dest: "{{ apache_etc_dir }}/mods-enabled/auth_openidc.load"
     state: link
@@ -81,8 +81,8 @@
         oidc_discover_uri is defined or
         oidc_discover_root is defined)
 
-- name: enable Suse apache mods
-  blockinfile:
+- name: Enable Suse apache mods
+  ansible.builtin.blockinfile:
     path: "{{ apache_etc_dir }}/loadmodule.conf"
     block: |
       LoadModule lua_module                     /usr/lib64/apache2-prefork/mod_lua.so
@@ -91,17 +91,17 @@
       LoadModule proxy_http_module              /usr/lib64/apache2-prefork/mod_proxy_http.so
   when: ansible_os_family == "Suse"
 
-- name: add OpenIDC config to Apache
-  template:
+- name: Add OpenIDC config to Apache
+  ansible.builtin.template:
     src: auth_openidc.conf.j2
     dest: "{{ apache_conf_dir }}/auth_openidc.conf"
     mode: 'u=rw,g=r,o='
     group: "{{ apache_user }}"
   when: ood_auth_openidc is defined
-  notify: restart apache httpd
+  notify: Restart apache httpd
 
-- name: start apache service
-  systemd:
+- name: Start apache service
+  ansible.builtin.systemd:
     name: "{{ apache_service_name }}"
     state: "{{ apache_service_state }}"
     enabled: "{{ apache_service_enabled }}"

--- a/tasks/deps.yml
+++ b/tasks/deps.yml
@@ -1,5 +1,5 @@
-- name: install the os dependencies
-  package:
+- name: Install the os dependencies
+  ansible.builtin.package:
     name: "{{ item }}"
     state: present
   loop:
@@ -7,14 +7,14 @@
   when: os_dependencies is defined
 
 - name: Add Nodesource apt key.
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
     id: "68576280"
     state: present
   when:  ansible_os_family == 'Debian'
 
 - name: Add NodeSource repositories for Node.js.
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "{{ item }}"
     state: present
   with_items:
@@ -23,13 +23,13 @@
   register: node_repo
   when:  ansible_os_family == 'Debian'
 
-- name: fresh debians need to update
-  apt:
+- name: Fresh debians need to update
+  ansible.builtin.apt:
     update_cache: yes
   when:  ansible_os_family == 'Debian'
 
-- name: install the dependencies
-  package:
+- name: Install the dependencies
+  ansible.builtin.package:
     name: "{{ item }}"
     state: present
   loop:
@@ -46,15 +46,15 @@
   - "{{ sqlite_devel_package }}"
   - "{{ ruby_devel_package }}"
 
-- name: install the npm on non-Debian
-  package:
+- name: Install the npm on non-Debian
+  ansible.builtin.package:
     name: "{{ item }}"
     state: present
   loop:
   - npm
   when: ansible_os_family != 'Debian'
 
-- name: install all the gems we need
+- name: Install all the gems we need
   community.general.gem:
     name: "{{ item.name }}"
     version: "{{ item.version }}"
@@ -65,13 +65,14 @@
   - { name: 'rake', version: '13.0.3' }
   - { name: 'bcrypt', version: '3.1.17' }
 
-- name: install apache openidc mod
-  package:
+- name: Install apache openidc mod
+  ansible.builtin.package:
     name: "{{ apache_oidc_mod_package }}"
     state: present
   when: oidc_uri is defined or
         oidc_discover_uri is defined or
         oidc_discover_root is defined
 
-- include: passenger.yml
-  become: false
+- name: Include passenger
+  ansible.builtin.import_tasks: passenger.yml
+  become: true

--- a/tasks/install-apps.yml
+++ b/tasks/install-apps.yml
@@ -1,5 +1,5 @@
 - name: Install OOD apps
-  git:
+  ansible.builtin.git:
     repo: "{{ item.value.repo }}"
     dest: "{{ item.value.dest | default(ood_sys_app_dir) }}/{{ item.key }}"
     version: "{{ item.value.version | default('master') }}"

--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -1,11 +1,11 @@
-- name: install the rpm repo's key
-  rpm_key:
+- name: Install the rpm repo's key
+  ansible.builtin.rpm_key:
     state: present
     key: "{{ rpm_repo_key }}"
   when: ansible_os_family == "RedHat"
 
-- name: install apt repo keys
-  apt_key:
+- name: Install apt repo keys
+  ansible.builtin.apt_key:
     state: present
     url: "{{ item.url }}"
     id: "{{ item.id }}"
@@ -14,29 +14,29 @@
   - { url: "{{ deb_repo_key }}", id: "{{ deb_repo_key_id }}" }
   - { url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key", id: "1655A0AB68576280" }
 
-- name: install the rpm repo
-  package:
+- name: Install the rpm repo
+  ansible.builtin.package:
     name: "{{ rpm_repo_url }}"
     state: present
     disable_gpg_check: "{{ disable_gpg_check_rpm_repo | bool }}"
   when: ansible_os_family == "RedHat"
 
-- name: install the apt repo
-  apt:
+- name: Install the apt repo
+  ansible.builtin.apt:
     deb: "{{ apt_repo_url }}"
     state: present
     update_cache: "{{ apt_update_cache | bool }}"
     dpkg_options: 'force-confnew'
   when: ansible_os_family == "Debian"
 
-- name: enable epel
-  package:
+- name: Enable epel
+  ansible.builtin.package:
     name: 'epel-release'
     state: present
   when: ansible_os_family == "RedHat"
 
-- name: install rhel/centos:8 dependencies
-  dnf:
+- name: Install rhel/centos:8 dependencies
+  ansible.builtin.dnf:
     name: "{{ item }}"
     enablerepo:
       - powertools
@@ -45,24 +45,24 @@
   loop:
     - "{{ additional_rpm_installs }}"
 
-- name: install additional packages
-  package:
+- name: Install additional packages
+  ansible.builtin.package:
     name: "{{ item }}"
     state: present
   loop:
   - "{{ additional_rpm_installs }}"
   when: additional_rpm_installs is defined
 
-- name: install apache openidc mod
-  package:
+- name: Install apache openidc mod
+  ansible.builtin.package:
     name: "{{ apache_oidc_mod_package }}"
     state: present
   when: oidc_uri is defined or
         oidc_discover_uri is defined or
         oidc_discover_root is defined
 
-- name: enable scl repos in rhel
-  shell: "subscription-manager repos --enable=rhel-server-rhscl-7-rpms"
+- name: Enable scl repos in rhel
+  ansible.builtin.command: "subscription-manager repos --enable=rhel-server-rhscl-7-rpms"
   when: ansible_distribution == "Red Hat Enterprise Linux" and ansible_distribution_major_version == '7'
 
 - name: Update cache (Debian)
@@ -85,8 +85,8 @@
     update_cache: true
   when: ansible_os_family == "Debian"
 
-- name: install ondemand-dex
-  package:
+- name: Install ondemand-dex
+  ansible.builtin.package:
     name: "{{ ondemand_dex_package }}"
     state: latest
   when: install_ondemand_dex

--- a/tasks/install-src.yml
+++ b/tasks/install-src.yml
@@ -1,5 +1,5 @@
-- name: make sure base directories exist
-  file:
+- name: Make sure base directories exist
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     owner: root
@@ -16,8 +16,8 @@
   - "{{ ood_base_apache_dir }}/discover"
   - "{{ ood_base_conf_dir }}"
 
-- name: make os directories when required
-  file:
+- name: Make os directories when required
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: 'u=rwx,g=rx,o=rx'
@@ -26,16 +26,16 @@
 
 # Have to remove these test directories because they don't copy well.  They have
 # recursive symlinks that throw OSError: [Errno 40] Too many levels of symbolic links
-- name: rm findit2 test directory
-  file:
+- name: Rm findit2 test directory
+  ansible.builtin.file:
     path: "{{ ood_source_dir }}/apps/files/{{ item }}"
     state: absent
   loop:
   - "node_modules/findit/test"
   - "lib/findit2/test"
 
-- name: move apps to their directories
-  copy:
+- name: Move apps to their directories
+  ansible.builtin.copy:
     src: "{{ ood_source_dir }}/apps/{{ item }}"
     dest: "{{ ood_sys_app_dir }}"
     owner: root
@@ -44,8 +44,8 @@
     remote_src: yes
   loop: "{{ ood_base_apps }}"
 
-- name: move core libs to their directories
-  copy:
+- name: Move core libs to their directories
+  ansible.builtin.copy:
     src: "{{ ood_source_dir }}/{{ item }}"
     dest: "{{ ood_base_dir }}"
     owner: root
@@ -54,8 +54,8 @@
     remote_src: yes
   loop: "{{ ood_core_libs }}"
 
-- name: make nginx config files for core sys apps
-  file:
+- name: Make nginx config files for core sys apps
+  ansible.builtin.file:
     path: "{{ nginx_apps_dir }}/sys/{{ item }}.conf"
     state: touch
     owner: root
@@ -63,20 +63,20 @@
     mode: 'u=rw,g=r,o=r'
   loop: "{{ ood_base_apps }}"
 
-- name: make version file
-  copy:
+- name: Make version file
+  ansible.builtin.copy:
     content: "{{ ood_source_version }}"
     dest: "{{ ood_base_dir }}/VERSION"
     mode: 'u=rw,g=r,o=r'
 
-- name: cleanup build logfiles
-  file:
+- name: Cleanup build logfiles
+  ansible.builtin.file:
     path: "{{ ood_sys_app_dir }}/log/production.log"
     state: absent
   loop: "{{ ood_base_apps }}"
 
-- name: give the apache user rights to nginx_stage
-  template:
+- name: Give the apache user rights to nginx_stage
+  ansible.builtin.template:
     src: ood-sudoers.j2
     dest: /etc/sudoers.d/ood
     mode: 'u=rw,g=,o='

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,49 +1,57 @@
-- name: include distribution variables
+- name: Include distribution variables
   block:
-    - name: include distribution variables
-      include_vars: "{{ item }}"
+    - name: Include distribution variables
+      ansible.builtin.include_vars: "{{ item }}"
       with_first_found:
-        - "{{ ansible_distribution }}/{{ ansible_distribution_major_version}}.yml"
+        - "{{ ansible_distribution }}/{{ ansible_distribution_major_version }}.yml"
         - "{{ ansible_distribution }}.yml"
       tags: [ 'always' ]
   rescue:
     - name: Change error message
-      fail: msg="unable to find anything in vars/ for this operating system! {{ ansible_distribution }}"
+      ansible.builtin.fail:
+        msg: "unable to find anything in vars/ for this operating system! {{ ansible_distribution }}"
 
-- name: include scl related overrides
-  include_vars: "{{ ansible_distribution }}-scl.yml"
+- name: Include scl related overrides
+  ansible.builtin.include_vars: "{{ ansible_distribution }}-scl.yml"
   when: (not install_from_src) and (ansible_os_family == "RedHat" and ansible_distribution_major_version < '8')
   tags: [ 'always' ]
 
-- include: deps.yml
+- name: Include dependencies when building from source
+  ansible.builtin.import_tasks: deps.yml
   become: true
   tags: [ 'deps' ]
   when: install_from_src
 
-- include: build.yml
+- name: Include built tasks when building from source
+  ansible.builtin.import_tasks: build.yml
   tags: [ 'build' ]
   when: install_from_src
 
-- include: install-src.yml
+- name: Include install tasks when building from source
+  ansible.builtin.import_tasks: install-src.yml
   become: true
   tags: [ 'install' ]
   when: install_from_src
 
-- include: install-package.yml
+- name: Include install tasks when installing package
+  ansible.builtin.import_tasks: install-package.yml
   become: true
   tags: [ 'install' ]
   when: not install_from_src
 
-- include: configure.yml
+- name: Include configure tasks when configuring
+  ansible.builtin.import_tasks: configure.yml
   become: true
   tags: [ 'configure' ]
 
-- include: install-apps.yml
+- name: Include install app tasks when installing apps
+  ansible.builtin.import_tasks: install-apps.yml
   when: ood_install_apps is defined
   become: true
   tags: [ 'install' ]
 
-- include: apps.yml
+- name: Include configure app tasks when configuring
+  ansible.builtin.import_tasks: apps.yml
   when: ood_apps is defined
   become: true
   tags: [ 'configure' ]

--- a/tasks/passenger.yml
+++ b/tasks/passenger.yml
@@ -1,5 +1,5 @@
-- name: ensure passenger src and destination directories exist
-  file:
+- name: Ensure passenger src and destination directories exist
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: 'u=rwx,g=rx,o=rx'
@@ -12,24 +12,25 @@
   - "{{ passenger_lib_dir }}"
   - "{{ passenger_support_binaries_dir }}"
 
-- name: init the passenger src directory
-  file:
+- name: Init the passenger src directory
+  ansible.builtin.file:
     path: "{{ passenger_src_dir }}"
     mode: 'u=rwx,g=rx,o=rx'
     state: directory
 
-- name: download the passenger tars
-  get_url:
+- name: Download the passenger tars
+  ansible.builtin.get_url:
     url: "{{ item }}"
     dest: "{{ passenger_src_dir }}"
+    mode: 'u=rw,g=r,o='
   when: passenger_remote_dl | bool
   loop:
   - "{{ passenger_url }}"
   - "{{ passenger_nginx_url }}"
   - "{{ passenger_agent_url }}"
 
-- name: extract the passenger tars
-  unarchive:
+- name: Extract the passenger tars
+  ansible.builtin.unarchive:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     mode: 'u=rwX,g=rX,o=rX'
@@ -40,15 +41,15 @@
   - { src: "{{ passenger_src_dir }}/{{ agent_tar }}", dest: "{{ passenger_support_binaries_dir }}" }
   - { src: "{{ passenger_src_dir }}/{{ nginx_tar }}", dest: "{{ nginx_dir }}/bin" }
 
-- name: copy nginx mime types files
-  copy:
+- name: Copy nginx mime types files
+  ansible.builtin.copy:
     src: "mime.types"
     dest: "{{ nginx_dir }}/conf"
     mode: 'u=rw,g=r,o=r'
   become: true
 
-- name: symlink passenger directory and nginx binary
-  file:
+- name: Symlink passenger directory and nginx binary
+  ansible.builtin.file:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     force: yes
@@ -58,8 +59,8 @@
   - { src: "{{ nginx_dir }}/bin/nginx-{{ nginx_version }}", dest: "{{ nginx_dir }}/bin/nginx" }
   - { src: "{{ ood_base_dir }}/passenger-{{ passenger_version }}", dest: "{{ passenger_base_dir }}" }
 
-- name: make nginx config dirs
-  file:
+- name: Make nginx config dirs
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: 'u=rwx,g=rx,o=rx'
@@ -73,23 +74,26 @@
   - "{{ nginx_apps_dir }}/usr"
   - "{{ nginx_apps_dir }}/dev"
 
-- name: make a tmp dir
-  shell: mktemp -d
+- name: Make a tmp dir
+  ansible.builtin.tempfile:
+    state: directory
   register: tmpdir
 
-- name: make passenger_native_support.so Makefile
-  shell: ruby {{ passenger_base_dir }}/src/ruby_native_extension/extconf.rb
+- name: Make passenger_native_support.so Makefile
+  ansible.builtin.command: ruby {{ passenger_base_dir }}/src/ruby_native_extension/extconf.rb
   args:
     chdir: "{{ tmpdir.stdout }}"
   become: true
+  changed_when: true
 
-- name: make the passenger_native_support.so
-  make:
+- name: Make the passenger_native_support.so
+  community.general.make:
     chdir: "{{ tmpdir.stdout }}"
   become: true
+  changed_when: true
 
-- name: move passenger_native_support.so to support libraries
-  copy:
+- name: Move passenger_native_support.so to support libraries
+  ansible.builtin.copy:
     src: "{{ tmpdir.stdout }}/passenger_native_support.so"
     dest:  "{{ ruby_lib_dir }}/passenger_native_support.so"
     owner: root
@@ -98,7 +102,7 @@
     remote_src: yes
   become: true
 
-- name: cleanup tmp dir
-  file:
+- name: Cleanup tmp dir
+  ansible.builtin.file:
     path: "{{ tmpdir.stdout }}"
     state: absent


### PR DESCRIPTION
Fixes #172 to fix all ansible-lint errors. The only remaining item is a single warning in our handler which will change in 2.1 anyhow when we remove building from the source.