### PR TITLE
Fixes paths for nginx on Ubuntu 20

### DIFF
--- a/molecule/default/fixtures/config/nginx_stage.yml.custom.Debian
+++ b/molecule/default/fixtures/config/nginx_stage.yml.custom.Debian
@@ -62,7 +62,7 @@ proxy_user: "www-data"
 
 # Path to NGINX executable used by OnDemand
 #
-nginx_bin: "/opt/rh/ondemand/root/sbin/nginx"
+nginx_bin: "/opt/ood/ondemand/root/usr/sbin/nginx"
 
 # White-list of signals that can be sent to the NGINX process
 #
@@ -74,7 +74,7 @@ nginx_bin: "/opt/rh/ondemand/root/sbin/nginx"
 
 # Path to NGINX 'mime.types' file used by OnDemand
 #
-mime_types_path: "/opt/rh/ondemand/root/etc/nginx/mime.types"
+mime_types_path: "/opt/ood/ondemand/root/etc/nginx/mime.types"
 
 # Path to Passenger 'locations.ini' file used by OnDemand.
 #

--- a/molecule/default/fixtures/config/nginx_stage.yml.default.Debian
+++ b/molecule/default/fixtures/config/nginx_stage.yml.default.Debian
@@ -59,7 +59,7 @@ proxy_user: "www-data"
 
 # Path to NGINX executable used by OnDemand
 #
-nginx_bin: "/opt/rh/ondemand/root/sbin/nginx"
+nginx_bin: "/opt/ood/ondemand/root/usr/sbin/nginx"
 
 # White-list of signals that can be sent to the NGINX process
 #
@@ -71,7 +71,7 @@ nginx_bin: "/opt/rh/ondemand/root/sbin/nginx"
 
 # Path to NGINX 'mime.types' file used by OnDemand
 #
-mime_types_path: "/opt/rh/ondemand/root/etc/nginx/mime.types"
+mime_types_path: "/opt/ood/ondemand/root/etc/nginx/mime.types"
 
 # Path to Passenger 'locations.ini' file used by OnDemand.
 #

--- a/vars/Ubuntu/20.yml
+++ b/vars/Ubuntu/20.yml
@@ -24,6 +24,6 @@ ruby_lib_dir: "/usr/lib/x86_64-linux-gnu/ruby/2.7.0"
 additional_rpm_installs: []
 
 nginx_root: "/opt/ood/ondemand/root"
-nginx_bin: "{{ nginx_root }}/sbin/nginx"
+nginx_bin: "{{ nginx_root }}/usr/sbin/nginx"
 nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
 locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"

--- a/vars/Ubuntu/20.yml
+++ b/vars/Ubuntu/20.yml
@@ -23,7 +23,7 @@ ruby_lib_dir: "/usr/lib/x86_64-linux-gnu/ruby/2.7.0"
 
 additional_rpm_installs: []
 
-nginx_root: "/opt/rh/ondemand/root"
+nginx_root: "/opt/ood/ondemand/root"
 nginx_bin: "{{ nginx_root }}/sbin/nginx"
 nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
 locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"


### PR DESCRIPTION
The paths for nginx indicated in the variables file for Ubuntu 20 have not been adapted to the Ubuntu environment. They are in fact paths specific to the RedHat environment.
This PR corrects the paths for Ubuntu 20.