### PR TITLE
fix molecule requirements for ci

### DIFF
--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,7 +1,7 @@
 ansible
 ansible-lint
+ansible_compat==3.0.2
 docker
-molecule-docker
-molecule-podman
 molecule
+molecule-plugins
 yamllint


### PR DESCRIPTION
Fix molecule requirements for CI because there have been updates upstream. Namely to use `molecule-plugins` instead of the specific plugins.  We also have to lock ansible_compat because there's another bug I ran into.