### PR TITLE
Allow fixing the `ondemand-dex` package version avoiding auto updates issue #194

### DIFF
--- a/defaults/main/install.yml
+++ b/defaults/main/install.yml
@@ -33,6 +33,9 @@ apt_update_cache: true
 
 # flip this flag if you want to install the ondemand-dex RPM
 install_ondemand_dex: false
+# This will default to latest ondemand-dex package if install_ondemand_dex
+# is set to true, to control the version installed add the version of the 
+# package to install (ondemand-dex-2.32.0)
 ondemand_dex_package: ondemand-dex
 
 # needed for testing. no reason to change these in production.

--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -89,5 +89,5 @@
 - name: Install ondemand-dex
   ansible.builtin.package:
     name: "{{ ondemand_dex_package }}"
-    state: latest
+    state: "{% if ondemand_dex_package == 'ondemand-dex' %}latest{% else %}present{% endif %}"
   when: install_ondemand_dex


### PR DESCRIPTION
This works the same way it is set for the `state` of `ondemand_package`, allowing to either go for latest if no version is defined or to stay in the version that was defined otherwise.
