### PR TITLE
added codeready repo for actual rhel deployments

### DIFF
--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -40,6 +40,7 @@
     name: "{{ item }}"
     enablerepo:
       - powertools
+      - codeready-builder-for-rhel-8-x86_64-rpms
     state: present
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '8'
   loop:


### PR DESCRIPTION
powertools is only available on centos/rocky/alma not rhel or oracle. rhel/oracle need codeready-builder enabled.