### PR TITLE
Add support_ticket option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,17 +30,23 @@ jobs:
           - 'centos:8'
           - 'rockylinux:8'
           - 'rockylinux:9'
+          - 'almalinux:8'
+          - 'almalinux:9'
           - 'ubuntu:20.04'
           - 'ubuntu:22.04'
         scenario:
           - 'default'
           - 'upgrade'
         exclude:
-          # 2.0 did not support rocky:9 and ubuntu:22
+          # 2.0 did not support el:9 and ubuntu:22
           - scenario: upgrade
             image: 'rockylinux:9'
           - scenario: upgrade
             image: 'ubuntu:22.04'
+          - scenario: upgrade
+            image: 'almalinux:8'
+          - scenario: upgrade
+            image: 'almalinux:9'
 
     steps:
       - name: checkout

--- a/defaults/main/.ondemand.yml
+++ b/defaults/main/.ondemand.yml
@@ -41,13 +41,13 @@
 #     from: "config@example.com"
 #     to: "support@example.com"
 #     delivery_method: "smtp"
-    # delivery_settings:
-    #   address: 'smtp.gmail.com'
-    #   port: 587
-    #   domain: 'example.com'
-    #   user_name: '<username>'
-    #   password: '<password>'
-    #   authentication: 'plain'
-    #   enable_starttls_auto: true
-    #   open_timeout: 15
-    #   read_timeout: 15
+#     delivery_settings:
+#       address: 'smtp.gmail.com'
+#       port: 587
+#       domain: 'example.com'
+#       user_name: '<username>'
+#       password: '<password>'
+#       authentication: 'plain'
+#       enable_starttls_auto: true
+#       open_timeout: 15
+#       read_timeout: 15

--- a/defaults/main/.ondemand.yml
+++ b/defaults/main/.ondemand.yml
@@ -30,3 +30,24 @@
 #         widgets:
 #           - xdmod_widget_job_efficiency
 #           - xdmod_widget_jobs
+
+# support_ticket:
+#   attachments:
+#     max_items: 4
+#     max_size: 2097152
+#   description: |
+#     My optional description Text for the support ticket feture
+#   email:
+#     from: "config@example.com"
+#     to: "support@example.com"
+#     delivery_method: "smtp"
+    # delivery_settings:
+    #   address: 'smtp.gmail.com'
+    #   port: 587
+    #   domain: 'example.com'
+    #   user_name: '<username>'
+    #   password: '<password>'
+    #   authentication: 'plain'
+    #   enable_starttls_auto: true
+    #   open_timeout: 15
+    #   read_timeout: 15

--- a/molecule/default/fixtures/ondemand.d/ondemand.yml
+++ b/molecule/default/fixtures/ondemand.d/ondemand.yml
@@ -26,3 +26,13 @@ dashboard_layout:
       - xdmod_widget_jobs
       width: 4
 
+
+support_ticket:
+  attachments:
+    max_items: 4
+    max_size: 6291456
+  description: 'My optional description Text for the support ticket feture '
+  email:
+    from: config@example.com
+    to: support@example.com
+

--- a/molecule/default/vars/ondemand.yml
+++ b/molecule/default/vars/ondemand.yml
@@ -22,3 +22,13 @@ dashboard_layout:
         widgets:
           - xdmod_widget_job_efficiency
           - xdmod_widget_jobs
+
+
+support_ticket:
+  attachments:
+    max_items: 4
+    max_size: 6291456
+  description: 'My optional description Text for the support ticket feture '
+  email:
+    from: config@example.com
+    to: support@example.com

--- a/vars/AlmaLinux/9.yml
+++ b/vars/AlmaLinux/9.yml
@@ -1,0 +1,16 @@
+---
+os_dependencies:
+- redhat-rpm-config
+- libnsl
+
+apache_oidc_mod_package:  mod_auth_openidc
+
+nginx_root: "/opt/rh/ondemand/root"
+nginx_bin: "{{ nginx_root }}/sbin/nginx"
+nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
+locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"
+
+additional_rpm_installs:
+  - lua-posix
+
+rpm_repo_key: https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand-SHA512


### PR DESCRIPTION
Hi Team,

I added the `support_ticket` option to the corresponding template and example in the defaults. Tested this in my environment and it seems to work okay.

Results of my `ondemand.d/ondemand.yml` (trimmed the empty lines)

```yaml
pinned_apps_menu_length: 6
pinned_apps_group_by: ""

pinned_apps:
  - sys/jupyter
  - sys/rstudio
  - sys/files
  - sys/shell
  - sys/bc_desktop/cluster

dashboard_layout:
  rows:
  - columns:
    - widgets:
      - motd
      - pinned_apps
      - recently_used_apps
      width: 8
    - widgets:
      - xdmod_widget_job_efficiency
      - xdmod_widget_jobs
      width: 4

support_ticket:
  attachments:
    max_items: 4
    max_size: 6291456
  description: 'My optional description Text for the support ticket feture '
  email:
    delivery_method: smtp
    delivery_settings:
      address: <SMTP>
      enable_starttls_auto: true
      open_timeout: 15
      port: 587
      read_timeout: 15
    from: config@example.com
    to: support@example.com

```