### PR TITLE
Created a copy from vars/RedHat/9.yml to vars/CentOS/9.yml

### DIFF
--- a/vars/CentOS/9.yml
+++ b/vars/CentOS/9.yml
@@ -1,0 +1,17 @@
+---
+os_dependencies:
+- redhat-rpm-config
+- libnsl
+- lua-posix
+
+apache_oidc_mod_package:  mod_auth_openidc
+
+nginx_root: "/opt/rh/ondemand/root"
+nginx_bin: "{{ nginx_root }}/sbin/nginx"
+nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
+locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"
+
+additional_rpm_installs:
+  - lua-posix
+
+rpm_repo_key: https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand-SHA512


### PR DESCRIPTION
Created a copy from vars/RedHat/9.yml to vars/CentOS/9.yml. The repository has no out-of-the-box support for CentOS 9 without this. The distributions are similar enough that a simple copy works.