### PR TITLE
Add parameter allowing to skip installation of repo config files

### DIFF
--- a/defaults/main/install.yml
+++ b/defaults/main/install.yml
@@ -31,6 +31,9 @@ ondemand_package_excludes: []
 disable_gpg_check_rpm_repo: true
 apt_update_cache: true
 
+# Set to "true" to skip installation of custom repo config files
+ood_use_exiting_repo_file: false
+
 # flip this flag if you want to install the ondemand-dex RPM
 install_ondemand_dex: false
 # This will default to latest ondemand-dex package if install_ondemand_dex

--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -19,7 +19,7 @@
     name: "{{ rpm_repo_url }}"
     state: present
     disable_gpg_check: "{{ disable_gpg_check_rpm_repo | bool }}"
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and not ood_use_exiting_repo_file
 
 - name: Install the apt repo
   ansible.builtin.apt:
@@ -27,13 +27,13 @@
     state: present
     update_cache: "{{ apt_update_cache | bool }}"
     dpkg_options: 'force-confnew'
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" and not ood_use_exiting_repo_file
 
 - name: Enable epel
   ansible.builtin.package:
     name: 'epel-release'
     state: present
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and not ood_use_exiting_repo_file
 
 - name: Install rhel/centos:8 dependencies
   ansible.builtin.dnf:


### PR DESCRIPTION
In some cases (for example when using a repo mirror) repo config files may already be present on the server and with this change makes it possible to skip tasks trying to modify existing configs.