### PR TITLE
make ondemand and ondemand_dex package installs idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,9 @@ new features to _this role_.
 
 ## Installing a specific version
 
-`ondemand_package` defaults to `latest` meaning this will install the latest version on the versioned
-yum/deb repository. For example, it'll install the latest version, 2.0.20 from the versioned 2.0 yum
-repo.
-
-We use `ondemand_package` for the `name` paramter of the [ansible yum](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/yum_module.html)
-so you can speicify a specific version with `ondemand-2.0.20` or use the comparison operators
-ansible supports.
+The `ondemand_package` variable controls the version of the rpm/dep package installed. The default value of `ondemand` will install the latest version from the relevant repository, but will not upgrade an
+existing installation. You can install a specific version using the full package name (e.g. `ondemand-3.0.3`) or use the comparison operators supported by the `name` parameter of the ansible [yum](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/yum_module.html)
+or [apt](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html) modules. Use `latest` to upgrade an existing installation.
 
 ### Installing from latest or nightly
 

--- a/defaults/main/install.yml
+++ b/defaults/main/install.yml
@@ -24,7 +24,7 @@ rpm_repo_key: "https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand"
 deb_repo_key: "https://apt.osc.edu/ondemand/DEB-GPG-KEY-ondemand"
 deb_repo_key_id: "4B72FE2B92D31755"
 
-ondemand_package: "ondemand"
+ondemand_package: "ondemand" # Idempotent. Use `latest` to upgrade, or full package name or comparison operators.
 ondemand_package_excludes: []
 
 # OSC's repo rpm isn't signed
@@ -33,10 +33,7 @@ apt_update_cache: true
 
 # flip this flag if you want to install the ondemand-dex RPM
 install_ondemand_dex: false
-# This will default to latest ondemand-dex package if install_ondemand_dex
-# is set to true, to control the version installed add the version of the 
-# package to install (ondemand-dex-2.32.0)
-ondemand_dex_package: ondemand-dex
+ondemand_dex_package: ondemand-dex # behaviour as for ondemand_package
 
 # needed for testing. no reason to change these in production.
 disable_htcacheclean: false

--- a/molecule/upgrade/converge.yml
+++ b/molecule/upgrade/converge.yml
@@ -3,3 +3,5 @@
   hosts: default
   roles:
     - role: ood-ansible
+  vars_files:
+    - vars/converge.yml

--- a/molecule/upgrade/vars/converge.yml
+++ b/molecule/upgrade/vars/converge.yml
@@ -1,0 +1,1 @@
+ondemand_package: 'latest'

--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -74,21 +74,21 @@
 
 - name: Install Open Ondemand (RHEL)
   ansible.builtin.yum:
-    name:  "{{ ondemand_package }}"
-    state: "{% if ondemand_package == 'ondemand' %}latest{% else %}present{% endif %}"
+    name:  "{{ 'ondemand' if ondemand_package == 'latest' else ondemand_package }}"
+    state: "{{ 'latest' if ondemand_package == 'latest' else 'present' }}"
     update_cache: true
     exclude: "{{ ondemand_package_excludes | default([]) }}"
   when: ansible_os_family == "RedHat"
 
 - name: Install Open Ondemand (Debian)
   ansible.builtin.apt:
-    name: "{{ ondemand_package }}"
-    state: "{% if ondemand_package == 'ondemand' %}latest{% else %}present{% endif %}"
+    name:  "{{ 'ondemand' if ondemand_package == 'latest' else ondemand_package }}"
+    state: "{{ 'latest' if ondemand_package == 'latest' else 'present' }}"
     update_cache: true
   when: ansible_os_family == "Debian"
 
 - name: Install ondemand-dex
   ansible.builtin.package:
-    name: "{{ ondemand_dex_package }}"
-    state: "{% if ondemand_dex_package == 'ondemand-dex' %}latest{% else %}present{% endif %}"
+    name: "{{ 'ondemand-dex' if ondemand_dex_package == 'latest' else ondemand-dex }}"
+    state: "{{ 'latest' if ondemand_dex_package == 'latest' else 'present' }}"
   when: install_ondemand_dex


### PR DESCRIPTION
The current defaults for `ondemand_package` and `ondemand_dex_package` aren't idempotent. This is problematic, as there is no way to get the behaviour of "install whatever the latest version is, then don't upgrade it on a rerun unless explicitly asked to". Note that *that* behaviour is the default yum/dnf behaviour.

This PR changes the behaviour of the defaults to be idempotent (hopefully that change is acceptable), and makes it so using `latest` is required to get an upgrade on an already-installed package.

The README changes have been made incorporating https://github.com/OSC/ood-ansible/pull/215