### PR TITLE
Add support for `help_menu`

### DIFF
--- a/defaults/main/.ondemand.yml
+++ b/defaults/main/.ondemand.yml
@@ -51,3 +51,20 @@
 #       enable_starttls_auto: true
 #       open_timeout: 15
 #       read_timeout: 15
+
+# help_menu:
+#   - group: "Documentation"
+#   - title: "Jupyter Docs"
+#     icon: "fas://book"
+#     url: "https://mydomain.com/path/jupyter"
+#   - title: "Support Docs"
+#     icon: "fas://book"
+#     url: "https://mydomain.com/path/support/docs"
+#   - group: "Custom Pages"
+#   - page: "rstudio_guide"
+#     title: "RStudio Guide"
+#     icon: "fas://window-restore"
+#   - group: "Profiles"
+#   - profile: "team1"
+#     title: "Team 1"
+#     icon: "fas://user"

--- a/molecule/default/fixtures/ondemand.d/ondemand.yml
+++ b/molecule/default/fixtures/ondemand.d/ondemand.yml
@@ -36,3 +36,4 @@ support_ticket:
     from: config@example.com
     to: support@example.com
 
+

--- a/templates/ondemand.yml.j2
+++ b/templates/ondemand.yml.j2
@@ -21,3 +21,8 @@ dashboard_layout:
 support_ticket:
   {{ support_ticket | to_nice_yaml(indent=2) | indent(2) }}
 {% endif %}
+
+{% if help_menu is defined %}
+help_menu:
+  {{ help_menu | to_nice_yaml(indent=2) | indent(2) }}
+{% endif %}


### PR DESCRIPTION
Update the template to include support for the `help_menu` element.
Update defaults with an example taken from the official documentation. 