### PR TITLE
fix galaxy publish 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Ansible.
-        run: pip3 install ansible-base
+        run: pip3 install ansible ansible-base
 
       - name: Trigger a new import on Galaxy.
         run: ansible-galaxy role import --api-key ${{ secrets.OSC_ROBOT_GALAXY_TOKEN }} OSC ood-ansible


### PR DESCRIPTION
This attempts to fix the publish to galaxy workflow that's currently failing with this error message:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.2/x64/bin/ansible-galaxy", line 62, in <module>
    import ansible.constants as C
  File "/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/site-packages/ansible/constants.py", line 15, in <module>
    from ansible.config.manager import ConfigManager, ensure_type, get_ini_config_value
  File "/opt/hostedtoolcache/Python/3.12.2/x64/lib/python3.12/site-packages/ansible/config/manager.py", line 29, in <module>
    from ansible.module_utils.six.moves import configparser
ModuleNotFoundError: No module named 'ansible.module_utils.six.moves'
```