### PR TITLE
Fix ondemand-dex package var name

### DIFF
--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -99,6 +99,6 @@
 
 - name: Install ondemand-dex
   ansible.builtin.package:
-    name: "{{ 'ondemand-dex' if ondemand_dex_package == 'latest' else ondemand-dex }}"
+    name: "{{ 'ondemand-dex' if ondemand_dex_package == 'latest' else ondemand_dex_package }}"
     state: "{{ 'latest' if ondemand_dex_package == 'latest' else 'present' }}"
   when: install_ondemand_dex


### PR DESCRIPTION
Current version of the role fails if you have `install_ondemand_dex` set to `true` as in https://github.com/OSC/ood-ansible/blob/2698b08951a8b4011d373253a06b9719f633109d/tasks/install-package.yml#L102 there is an non valid and undefined variable name `ondemand-dex` instead of `ondemand_dex_package`. 
In this case the role fails:
```
TASK [osc.open_ondemand : Install ondemand-dex] *****************************************************************************************************************************************************************************************************************************************
fatal: [ood-ubuntu-devel.scicore.unibas.ch]: FAILED! => 
  msg: |-
    The task includes an option with an undefined variable. The error was: 'ondemand' is undefined. 'ondemand' is undefined
  
    The error appears to be in '/home/martin0009/ansible/playbooks/playbook-scicore-int/roles/osc.open_ondemand/tasks/install-package.yml': line 100, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
  
    - name: Install ondemand-dex
      ^ here
```

Fixes #235