### PR TITLE
Also use a var when adding the node repo key

### DIFF
--- a/defaults/main/install.yml
+++ b/defaults/main/install.yml
@@ -1,5 +1,5 @@
 # This file holds install related configurations as well as base directories for
-# configuration files. 
+# configuration files.
 
 ood_base_conf_dir: "/etc/ood/config"
 ood_app_dir: "{{ ood_base_apache_dir }}/apps"
@@ -23,6 +23,8 @@ apt_repo_url: "https://apt.osc.edu/ondemand/3.1/ondemand-release-web_3.1.1-{{ de
 rpm_repo_key: "https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand"
 deb_repo_key: "https://apt.osc.edu/ondemand/DEB-GPG-KEY-ondemand"
 deb_repo_key_id: "4B72FE2B92D31755"
+node_repo_key: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
+node_repo_key_id: "1655A0AB68576280"
 
 ondemand_package: "ondemand" # Idempotent. Use `latest` to upgrade, or full package name or comparison operators.
 ondemand_package_excludes: []

--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -22,7 +22,7 @@
   when: ansible_os_family == "Debian"
   loop:
   - { url: "{{ deb_repo_key }}", id: "{{ deb_repo_key_id }}" }
-  - { url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key", id: "1655A0AB68576280" }
+  - { url: "{{ node_repo_key }}", id: "{{ node_repo_key_id }}" }
 
 - name: Install the rpm repo
   ansible.builtin.package:


### PR DESCRIPTION
We would like to use our internal mirror and this change allows to use custom urls instead of hardcoded ones