### PR TITLE
Fix missing quotes in RedHat 9 vars

### DIFF
--- a/vars/RedHat/9.yml
+++ b/vars/RedHat/9.yml
@@ -13,7 +13,7 @@ locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passen
 
 additional_rpm_installs:
   - lua-posix
-  - @nodejs:{{ nodejs_version }}
-  - @ruby:{{ ruby_version }}
+  - "@nodejs:{{ nodejs_version }}"
+  - "@ruby:{{ ruby_version }}"
 
 rpm_repo_key: https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand-SHA512


### PR DESCRIPTION
Vars for RedHat 9 are missing quotes. 

This causes errors when using the role as Ansible cannot parse the YAML syntax.