### PR TITLE
remove task updating apt cache on every execution

### DIFF
--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -77,11 +77,6 @@
   when: ansible_distribution == "Red Hat Enterprise Linux" and ansible_distribution_major_version == '7'
   changed_when: true
 
-- name: Update cache (Debian)
-  ansible.builtin.apt:
-    update_cache: true
-  when: ansible_os_family == "Debian"
-
 - name: Install Open Ondemand (RHEL)
   ansible.builtin.yum:
     name:  "{{ 'ondemand' if ondemand_package == 'latest' else ondemand_package }}"


### PR DESCRIPTION
The role is not idempotent because of this task that is executed on every run

Removing this task should make the role idempotent and should not affect the current behavior as the cache is anyway updated in the task installing the package in https://github.com/OSC/ood-ansible/blob/master/tasks/install-package.yml#L97