### PR TITLE
more flexible ondemand.d configurations.

### DIFF
--- a/defaults/main/ondemand.yml
+++ b/defaults/main/ondemand.yml
@@ -93,3 +93,5 @@ hide_app_version: false
 # google_analytics_tag_id: null
 
 motd_render_html: false
+
+# ood_ondemand_d_configs: {}

--- a/molecule/default/fixtures/ondemand.d/motd.yml
+++ b/molecule/default/fixtures/ondemand.d/motd.yml
@@ -1,0 +1,1 @@
+motd_render_html: true

--- a/molecule/default/fixtures/ondemand.d/ondemand_custom.yml
+++ b/molecule/default/fixtures/ondemand.d/ondemand_custom.yml
@@ -72,5 +72,3 @@ globus_endpoints:
 
 
 google_analytics_tag_id: abc123
-
-motd_render_html: true

--- a/molecule/default/fixtures/ondemand.d/ondemand_custom.yml
+++ b/molecule/default/fixtures/ondemand.d/ondemand_custom.yml
@@ -72,3 +72,5 @@ globus_endpoints:
 
 
 google_analytics_tag_id: abc123
+
+motd_render_html: true

--- a/molecule/default/tasks/verify_custom.yml
+++ b/molecule/default/tasks/verify_custom.yml
@@ -11,6 +11,7 @@
     - { src: "fixtures/apps/bc_desktop/", dest: "bc_desktop/" }
     - { src: "fixtures/config/auth_openidc.conf", dest: "auth_openidc.conf" }
     - { src: "fixtures/ondemand.d/ondemand_custom.yml", dest: "ondemand.yml" }
+    - { src: "fixtures/ondemand.d/motd.yml", dest: "motd.yml" }
 
 - name: Verify config files
   ansible.builtin.command: "diff /tmp/{{ item.left }} {{ item.right }}"
@@ -23,6 +24,7 @@
     - { left: "bc_desktop/submit/submit.yml.erb", right: "{{ ood_base_conf_dir }}/apps/bc_desktop/submit/submit.yml.erb" }
     - { left: "auth_openidc.conf", right: "{{ apache_conf_dir }}/auth_openidc.conf" }
     - { left: "ondemand.yml", right: "{{ ood_base_conf_dir }}/ondemand.d/ondemand.yml" }
+    - { left: "motd.yml", right: "{{ ood_base_conf_dir }}/ondemand.d/motd.yml" }
   changed_when: false
 
 - name: Verify sys/jupyter was installed correctly

--- a/molecule/default/vars/ondemand.yml
+++ b/molecule/default/vars/ondemand.yml
@@ -65,6 +65,8 @@ globus_endpoints:
 
 google_analytics_tag_id: 'abc123'
 
+motd_render_html: true
+
 ood_ondemand_d_configs:
   motd:
     content:

--- a/molecule/default/vars/ondemand.yml
+++ b/molecule/default/vars/ondemand.yml
@@ -65,4 +65,7 @@ globus_endpoints:
 
 google_analytics_tag_id: 'abc123'
 
-motd_render_html: true
+ood_ondemand_d_configs:
+  motd:
+    content:
+      motd_render_html: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -35,6 +35,16 @@
     dest: "{{ ood_base_conf_dir }}/ondemand.d/ondemand.yml"
     mode: 'u=rw,g=r,o=r'
 
+- name: Create other ondemand.d files
+  copy:
+    content: "{{ ood_ondemand_d_configs[item].content | to_nice_yaml }}"
+    dest: "{{ ood_base_conf_dir }}/ondemand.d/{{ item }}.yml"
+    mode: "{{ ood_ondemand_d_configs[item].mode | default('644') }}"
+    group: "{{ ood_ondemand_d_configs[item].group | default('root') }}"
+  loop: "{{ ood_ondemand_d_configs | list | default([]) }}"
+  when: ood_ondemand_d_configs is defined
+
+
 - name: Enable Debian apache mods
   ansible.builtin.file:
     src: "{{ apache_etc_dir }}/mods-available/{{ item }}.load"


### PR DESCRIPTION
Fixes #257 by allowing for `ood_ondemand_d_configs` which is a hash of all the things you'd like to specify in `ondemand.d` files.

Here in this test case, I've given this configuration. 

```yaml
ood_ondemand_d_configs:
  motd:
    content:
      motd_render_html: true
```

Which will ultimately write out this content to `ondemand.d/motd.yml`. 
```yaml
motd_render_html: true
```