### PR TITLE
Provide variables for Ubuntu 24

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
           - 'almalinux:9'
           - 'ubuntu:20.04'
           - 'ubuntu:22.04'
+          - 'ubuntu:24.04'
         scenario:
           - 'default'
           - 'upgrade'

--- a/vars/Ubuntu/24.yml
+++ b/vars/Ubuntu/24.yml
@@ -1,0 +1,29 @@
+---
+apache_package_name: apache2
+apache_service_name: apache2
+apache_user: www-data
+apache_etc_dir: "/etc/{{ apache_service_name }}"
+apache_conf_dir: "{{ apache_etc_dir }}/sites-enabled"
+apache_log_dir: "/var/log/{{ apache_service_name }}"
+container_apache_restart_cmd: ". {{ apache_etc_dir }}/envvars && /usr/sbin/apache2 -k start"
+apache_oidc_mod_package:  libapache2-mod-auth-openidc
+
+sqlite_devel_package: libsqlite3-dev
+ruby_devel_package: ruby-dev
+ffi_devel_package: libffi-dev
+libz_devel_package: zlib1g-dev
+
+os_dependencies:
+- tzdata
+
+os_directories:
+- "/var/run/{{ apache_service_name }}"
+
+ruby_lib_dir: "/usr/lib/x86_64-linux-gnu/ruby/3.2.0"
+
+additional_rpm_installs: []
+
+nginx_root: "/opt/ood/ondemand/root"
+nginx_bin: "{{ nginx_root }}/usr/sbin/nginx"
+nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
+locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"


### PR DESCRIPTION
This pull request adds the variables for Ubuntu 24 to vars/Ubuntu/24.yml.
It is adapted from the Ubuntu 20 variables file. The only required change from previous Ubuntu versions is the ruby_lib_dir which changed to version 3.2. All package names are still the same.

I performed a successful OnDemand installation on Ubuntu 24 (noble) with the provided variables.