### PR TITLE
Passenger telemetry

### DIFF
--- a/defaults/main/nginx_stage.yml
+++ b/defaults/main/nginx_stage.yml
@@ -7,7 +7,6 @@
 pun_custom_env_declarations: []
 # pun_custom_env is undefined by default
 passenger_pool_idle_time: 300
-passenger_disable_anonymous_telemetry: on
 passenger_options: {}
 
 # user_regex: '[\w@\.\-]+'
@@ -21,3 +20,7 @@ nginx_bin: "{{ nginx_dir }}/bin/nginx"
 nginx_mime_types: "{{ nginx_dir }}/conf/mime.types"
 nginx_file_upload_max: 10737420000
 locations_ini: "{{ passenger_lib_dir }}/locations.ini"
+
+# passenger_disable_anonymous_telemetry is not defined as it's not supported
+# in many versions.
+# passenger_disable_anonymous_telemetry: on

--- a/defaults/main/nginx_stage.yml
+++ b/defaults/main/nginx_stage.yml
@@ -7,6 +7,7 @@
 pun_custom_env_declarations: []
 # pun_custom_env is undefined by default
 passenger_pool_idle_time: 300
+passenger_disable_anonymous_telemetry: on
 passenger_options: {}
 
 # user_regex: '[\w@\.\-]+'

--- a/molecule/default/fixtures/config/nginx_stage.yml
+++ b/molecule/default/fixtures/config/nginx_stage.yml
@@ -91,11 +91,6 @@ passenger_root: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passe
 #
 #passenger_python: '/opt/ood/nginx_stage/bin/python'
 
-# Option to disable the Passenger telemetry.
-# Set to `on` if you don't want to regularly send anonymous telemetry data to Phusion
-#
-passenger_disable_anonymous_telemetry: on
-
 # Max file upload size in bytes (e.g., 10737420000)
 #
 nginx_file_upload_max: 10737420000

--- a/molecule/default/fixtures/config/nginx_stage.yml
+++ b/molecule/default/fixtures/config/nginx_stage.yml
@@ -91,6 +91,11 @@ passenger_root: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passe
 #
 #passenger_python: '/opt/ood/nginx_stage/bin/python'
 
+# Option to disable the Passenger telemetry.
+# Set to `on` if you don't want to regularly send anonymous telemetry data to Phusion
+#
+passenger_disable_anonymous_telemetry: on
+
 # Max file upload size in bytes (e.g., 10737420000)
 #
 nginx_file_upload_max: 10737420000

--- a/molecule/default/fixtures/config/nginx_stage.yml.custom.Debian
+++ b/molecule/default/fixtures/config/nginx_stage.yml.custom.Debian
@@ -99,6 +99,11 @@ passenger_root: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passe
 #
 passenger_pool_idle_time: 400
 
+# Option to disable the Passenger telemetry.
+# Set to `on` if you don't want to regularly send anonymous telemetry data to Phusion
+#
+passenger_disable_anonymous_telemetry: on
+
 # Hash of Passenger configuration options
 # Keys without passenger_ prefix will be ignored
 #

--- a/molecule/default/fixtures/config/nginx_stage.yml.custom.RedHat
+++ b/molecule/default/fixtures/config/nginx_stage.yml.custom.RedHat
@@ -99,6 +99,11 @@ passenger_root: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passe
 #
 passenger_pool_idle_time: 400
 
+# Option to disable the Passenger telemetry.
+# Set to `on` if you don't want to regularly send anonymous telemetry data to Phusion
+#
+passenger_disable_anonymous_telemetry: on
+
 # Hash of Passenger configuration options
 # Keys without passenger_ prefix will be ignored
 #

--- a/molecule/default/fixtures/config/nginx_stage.yml.default.Debian
+++ b/molecule/default/fixtures/config/nginx_stage.yml.default.Debian
@@ -96,6 +96,11 @@ passenger_root: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passe
 #
 passenger_pool_idle_time: 300
 
+# Option to disable the Passenger telemetry.
+# Set to `on` if you don't want to regularly send anonymous telemetry data to Phusion
+#
+#passenger_disable_anonymous_telemetry: on
+
 # Hash of Passenger configuration options
 # Keys without passenger_ prefix will be ignored
 #

--- a/molecule/default/fixtures/config/nginx_stage.yml.default.RedHat
+++ b/molecule/default/fixtures/config/nginx_stage.yml.default.RedHat
@@ -96,6 +96,11 @@ passenger_root: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passe
 #
 passenger_pool_idle_time: 300
 
+# Option to disable the Passenger telemetry.
+# Set to `on` if you don't want to regularly send anonymous telemetry data to Phusion
+#
+#passenger_disable_anonymous_telemetry: on
+
 # Hash of Passenger configuration options
 # Keys without passenger_ prefix will be ignored
 #

--- a/molecule/default/vars/nginx.yml
+++ b/molecule/default/vars/nginx.yml
@@ -9,3 +9,5 @@ passenger_options:
 
 pun_custom_env:
   MY_ENV_VAR: 'is so cool'
+
+passenger_disable_anonymous_telemetry: 'on'

--- a/molecule/default/vars/nginx.yml
+++ b/molecule/default/vars/nginx.yml
@@ -4,7 +4,6 @@ user_regex: '^[A-Za-z0-9\-_\.]+@osu.edu$'
 pun_log_format: '$status|"$http_referer"|"$http_user_agent"|"$http_x_forwarded_for|$body_bytes_sent|$remote_addr|$remote_user|$time_local|"$request"'
 
 passenger_pool_idle_time: 400
-passenger_disable_anonymous_telemetry: on
 passenger_options:
   passenger_stat_throttle_rate: 60
 

--- a/molecule/default/vars/nginx.yml
+++ b/molecule/default/vars/nginx.yml
@@ -4,6 +4,7 @@ user_regex: '^[A-Za-z0-9\-_\.]+@osu.edu$'
 pun_log_format: '$status|"$http_referer"|"$http_user_agent"|"$http_x_forwarded_for|$body_bytes_sent|$remote_addr|$remote_user|$time_local|"$request"'
 
 passenger_pool_idle_time: 400
+passenger_disable_anonymous_telemetry: on
 passenger_options:
   passenger_stat_throttle_rate: 60
 

--- a/templates/nginx_stage.yml.j2
+++ b/templates/nginx_stage.yml.j2
@@ -110,6 +110,11 @@ passenger_root: "{{ locations_ini }}"
 #
 passenger_pool_idle_time: {{ passenger_pool_idle_time }}
 
+# Option to disable the Passenger telemetry.
+# Set to `on` if you don't want to regularly send anonymous telemetry data to Phusion
+#
+passenger_disable_anonymous_telemetry: {{ passenger_disable_anonymous_telemetry }}
+
 # Hash of Passenger configuration options
 # Keys without passenger_ prefix will be ignored
 #

--- a/templates/nginx_stage.yml.j2
+++ b/templates/nginx_stage.yml.j2
@@ -110,10 +110,12 @@ passenger_root: "{{ locations_ini }}"
 #
 passenger_pool_idle_time: {{ passenger_pool_idle_time }}
 
+{% if passenger_disable_anonymous_telemetry is defined -%}
 # Option to disable the Passenger telemetry.
 # Set to `on` if you don't want to regularly send anonymous telemetry data to Phusion
 #
 passenger_disable_anonymous_telemetry: {{ passenger_disable_anonymous_telemetry }}
+{%- endif -%}
 
 # Hash of Passenger configuration options
 # Keys without passenger_ prefix will be ignored

--- a/templates/nginx_stage.yml.j2
+++ b/templates/nginx_stage.yml.j2
@@ -110,12 +110,14 @@ passenger_root: "{{ locations_ini }}"
 #
 passenger_pool_idle_time: {{ passenger_pool_idle_time }}
 
-{% if passenger_disable_anonymous_telemetry is defined -%}
 # Option to disable the Passenger telemetry.
 # Set to `on` if you don't want to regularly send anonymous telemetry data to Phusion
 #
+{% if passenger_disable_anonymous_telemetry is defined %}
 passenger_disable_anonymous_telemetry: {{ passenger_disable_anonymous_telemetry }}
-{%- endif -%}
+{% else %}
+#passenger_disable_anonymous_telemetry: on
+{% endif %}
 
 # Hash of Passenger configuration options
 # Keys without passenger_ prefix will be ignored


### PR DESCRIPTION
This PR implements the option to disable the Passenger telemetry as requested in https://github.com/OSC/ondemand/issues/4347.
It is for now marked as draft since it requires changes to the ondemand repository being merged first in PR https://github.com/OSC/ondemand/pull/4355

This PR includes changes in the previous PR https://github.com/OSC/ood-ansible/pull/270.