### PR TITLE
allow users to manage repository files in this role

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This ansible role installs and configures [Open OnDemand](https://openondemand.o
 ## Table of Contents
 
 - [Version compatibility](#version-compatibility)
+- [Install a specific version](#installing-a-specific-version)
 - [Tags](#tags)
 - [Overrides](#overrides)
   - [Using this role to manage cluster and apps](#using-this-role-to-manage-cluster-and-apps)
@@ -65,6 +66,15 @@ ondemand_package: 'ondemand-2.0.20'
 ondemand_package_excludes:
   - '*-2.1'
 ```
+
+### Install from different repository
+
+There are two ways to install from a different repository other than the one provided
+by OSC. Users can either set `ood_use_existing_repo_file` to `true` (defaults to `false`)
+and provide a different repository file outside this role. Or they can set `ood_dl_repo_package`
+to `false` and let this role template a repository file. The templated file this role provides
+uses `ood_repo_base_url` and `ood_repo_src_base_url` variables, though `ood_repo_src_base_url`
+is only applicable to RHEL type systems.
 
 ## Tags
 

--- a/defaults/main/install.yml
+++ b/defaults/main/install.yml
@@ -36,6 +36,13 @@ apt_update_cache: true
 # Set to "true" to skip installation of custom repo config files
 ood_use_existing_repo_file: false
 
+# basically the same as 'ood_use_existing_repo_file' but when both are set to false this
+# role will manage the repository file.
+# When both this and 'ood_use_existing_repo_file' set to false, users can supply different
+# repo_base_url and repo_src_base_url variables to look at a different repository, though 'repo_src_base_url'
+# is only available for RHEL type systems.
+dl_repo_package: true
+
 # flip this flag if you want to install the ondemand-dex RPM
 install_ondemand_dex: false
 ondemand_dex_package: ondemand-dex # behaviour as for ondemand_package

--- a/defaults/main/install.yml
+++ b/defaults/main/install.yml
@@ -36,11 +36,14 @@ apt_update_cache: true
 # Set to "true" to skip installation of custom repo config files
 ood_use_existing_repo_file: false
 
-# basically the same as 'ood_use_existing_repo_file' but when both are set to false this
-# role will manage the repository file.
-# When both this and 'ood_use_existing_repo_file' set to false, users can supply different
-# repo_base_url and repo_src_base_url variables to look at a different repository, though 'repo_src_base_url'
-# is only available for RHEL type systems.
+# Similar to 'ood_use_existing_repo_file' only that this role will populate the
+# repository files instead of downloading a package that does the same. When
+# using 'ood_use_existing_repo_file' users supply the repository file outside of this role.
+#
+# When both are set to false this this role will manage the repository file.
+# Users can supply different 'repo_base_url' and 'repo_src_base_url' variables to look
+# at a different repository. Though 'repo_src_base_url' is only available for RHEL
+# type systems.
 dl_repo_package: true
 
 # flip this flag if you want to install the ondemand-dex RPM

--- a/defaults/main/install.yml
+++ b/defaults/main/install.yml
@@ -44,7 +44,7 @@ ood_use_existing_repo_file: false
 # Users can supply different 'repo_base_url' and 'repo_src_base_url' variables to look
 # at a different repository. Though 'repo_src_base_url' is only available for RHEL
 # type systems.
-dl_repo_package: true
+ood_dl_repo_package: true
 
 # flip this flag if you want to install the ondemand-dex RPM
 install_ondemand_dex: false

--- a/defaults/main/install.yml
+++ b/defaults/main/install.yml
@@ -41,8 +41,8 @@ ood_use_existing_repo_file: false
 # using 'ood_use_existing_repo_file' users supply the repository file outside of this role.
 #
 # When both are set to false this this role will manage the repository file.
-# Users can supply different 'repo_base_url' and 'repo_src_base_url' variables to look
-# at a different repository. Though 'repo_src_base_url' is only available for RHEL
+# Users can supply different 'ood_repo_base_url' and 'ood_repo_src_base_url' variables to look
+# at a different repository. Though 'ood_repo_src_base_url' is only available for RHEL
 # type systems.
 ood_dl_repo_package: true
 

--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -29,7 +29,16 @@
     name: "{{ rpm_repo_url }}"
     state: present
     disable_gpg_check: "{{ disable_gpg_check_rpm_repo | bool }}"
-  when: ansible_os_family == "RedHat" and not ood_use_existing_repo_file
+  when: ansible_os_family == "RedHat" and dl_repo_package and not ood_use_existing_repo_file
+
+- name: Create repo file (RHEL)
+  ansible.builtin.template:
+    src: ondemand-web.repo.j2
+    dest: /etc/yum.repos.d/ondemand-web.repo
+    mode: 'u=rw,g=r,o=r'
+    owner: root
+    group: root
+  when: ansible_os_family == "RedHat" and not dl_repo_package and not ood_use_existing_repo_file
 
 - name: Install the apt repo
   ansible.builtin.apt:
@@ -37,7 +46,16 @@
     state: present
     update_cache: "{{ apt_update_cache | bool }}"
     dpkg_options: 'force-confnew'
-  when: ansible_os_family == "Debian" and not ood_use_existing_repo_file
+  when: ansible_os_family == "Debian" and dl_repo_package and not ood_use_existing_repo_file
+
+- name: Create repo file (Debian)
+  ansible.builtin.template:
+    src: ondemand-web.list.j2
+    dest: /etc/apt/sources.list.d/ondemand-web.list
+    mode: 'u=rw,g=r,o=r'
+    owner: root
+    group: root
+  when: ansible_os_family == "Debian" and not dl_repo_package and not ood_use_existing_repo_file
 
 - name: Enable epel
   ansible.builtin.package:

--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -14,6 +14,13 @@
     key: "{{ rpm_repo_key }}"
   when: ansible_os_family == "RedHat"
 
+- name: Install the rpm repo's key to /etc
+  ansible.builtin.get_url:
+    url: "{{ rpm_repo_key }}"
+    dest: /etc/pki/rpm-gpg
+    mode: '0600'
+  when: ansible_os_family == "RedHat" and not ood_dl_repo_package and not ood_use_existing_repo_file
+
 - name: Install apt repo keys
   ansible.builtin.apt_key:
     state: present

--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -29,7 +29,7 @@
     name: "{{ rpm_repo_url }}"
     state: present
     disable_gpg_check: "{{ disable_gpg_check_rpm_repo | bool }}"
-  when: ansible_os_family == "RedHat" and dl_repo_package and not ood_use_existing_repo_file
+  when: ansible_os_family == "RedHat" and ood_dl_repo_package and not ood_use_existing_repo_file
 
 - name: Create repo file (RHEL)
   ansible.builtin.template:
@@ -38,7 +38,7 @@
     mode: 'u=rw,g=r,o=r'
     owner: root
     group: root
-  when: ansible_os_family == "RedHat" and not dl_repo_package and not ood_use_existing_repo_file
+  when: ansible_os_family == "RedHat" and not ood_dl_repo_package and not ood_use_existing_repo_file
 
 - name: Install the apt repo
   ansible.builtin.apt:
@@ -46,7 +46,7 @@
     state: present
     update_cache: "{{ apt_update_cache | bool }}"
     dpkg_options: 'force-confnew'
-  when: ansible_os_family == "Debian" and dl_repo_package and not ood_use_existing_repo_file
+  when: ansible_os_family == "Debian" and ood_dl_repo_package and not ood_use_existing_repo_file
 
 - name: Create repo file (Debian)
   ansible.builtin.template:
@@ -55,7 +55,7 @@
     mode: 'u=rw,g=r,o=r'
     owner: root
     group: root
-  when: ansible_os_family == "Debian" and not dl_repo_package and not ood_use_existing_repo_file
+  when: ansible_os_family == "Debian" and not ood_dl_repo_package and not ood_use_existing_repo_file
 
 - name: Enable epel
   ansible.builtin.package:

--- a/templates/ondemand-web.list.j2
+++ b/templates/ondemand-web.list.j2
@@ -1,0 +1,1 @@
+deb {{ repo_base_url }} {{ ansible_distribution_release }} main

--- a/templates/ondemand-web.list.j2
+++ b/templates/ondemand-web.list.j2
@@ -1,1 +1,1 @@
-deb {{ repo_base_url }} {{ ansible_distribution_release }} main
+deb {{ ood_repo_base_url }} {{ ansible_distribution_release }} main

--- a/templates/ondemand-web.repo.j2
+++ b/templates/ondemand-web.repo.j2
@@ -1,0 +1,15 @@
+[ondemand-web]
+name=Open OnDemand Web Repo
+baseurl={{ repo_base_url }}
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ondemand
+
+[ondemand-web-source]
+name=Open OnDemand Web Repo
+baseurl={{ repo_src_base_url }}
+enabled=0
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ondemand

--- a/templates/ondemand-web.repo.j2
+++ b/templates/ondemand-web.repo.j2
@@ -1,6 +1,6 @@
 [ondemand-web]
 name=Open OnDemand Web Repo
-baseurl={{ repo_base_url }}
+baseurl={{ ood_repo_base_url }}
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ondemand
 
 [ondemand-web-source]
 name=Open OnDemand Web Repo
-baseurl={{ repo_src_base_url }}
+baseurl={{ ood_repo_src_base_url }}
 enabled=0
 gpgcheck=1
 repo_gpgcheck=1

--- a/vars/AlmaLinux/8.yml
+++ b/vars/AlmaLinux/8.yml
@@ -14,3 +14,6 @@ additional_rpm_installs:
   - lua-posix
   - "@ruby:{{ ruby_version }}"
   - "@nodejs:{{ nodejs_version }}"
+
+repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/$basearch/'
+repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/SRPMS/'

--- a/vars/AlmaLinux/8.yml
+++ b/vars/AlmaLinux/8.yml
@@ -15,5 +15,5 @@ additional_rpm_installs:
   - "@ruby:{{ ruby_version }}"
   - "@nodejs:{{ nodejs_version }}"
 
-repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/$basearch/'
-repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/SRPMS/'
+ood_repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/$basearch/'
+ood_repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/SRPMS/'

--- a/vars/AlmaLinux/9.yml
+++ b/vars/AlmaLinux/9.yml
@@ -16,3 +16,6 @@ additional_rpm_installs:
   - '@ruby:{{ ruby_version }}'
 
 rpm_repo_key: https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand-SHA512
+
+repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/$basearch/'
+repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/SRPMS/'

--- a/vars/AlmaLinux/9.yml
+++ b/vars/AlmaLinux/9.yml
@@ -17,5 +17,5 @@ additional_rpm_installs:
 
 rpm_repo_key: https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand-SHA512
 
-repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/$basearch/'
-repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/SRPMS/'
+ood_repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/$basearch/'
+ood_repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/SRPMS/'

--- a/vars/RedHat/8.yml
+++ b/vars/RedHat/8.yml
@@ -15,3 +15,6 @@ additional_rpm_installs:
   - lua-posix
   - "@ruby:{{ ruby_version }}"
   - "@nodejs:{{ nodejs_version }}"
+
+repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/$basearch/'
+repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/SRPMS/'

--- a/vars/RedHat/8.yml
+++ b/vars/RedHat/8.yml
@@ -16,5 +16,5 @@ additional_rpm_installs:
   - "@ruby:{{ ruby_version }}"
   - "@nodejs:{{ nodejs_version }}"
 
-repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/$basearch/'
-repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/SRPMS/'
+ood_repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/$basearch/'
+ood_repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/SRPMS/'

--- a/vars/RedHat/9.yml
+++ b/vars/RedHat/9.yml
@@ -17,3 +17,6 @@ additional_rpm_installs:
   - "@ruby:{{ ruby_version }}"
 
 rpm_repo_key: https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand-SHA512
+
+repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/$basearch/'
+repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/SRPMS/'

--- a/vars/RedHat/9.yml
+++ b/vars/RedHat/9.yml
@@ -18,5 +18,5 @@ additional_rpm_installs:
 
 rpm_repo_key: https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand-SHA512
 
-repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/$basearch/'
-repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/SRPMS/'
+ood_repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/$basearch/'
+ood_repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/SRPMS/'

--- a/vars/Rocky/8.yml
+++ b/vars/Rocky/8.yml
@@ -14,3 +14,6 @@ additional_rpm_installs:
   - lua-posix
   - "@ruby:{{ ruby_version }}"
   - "@nodejs:{{ nodejs_version }}"
+
+repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/$basearch/'
+repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/SRPMS/'

--- a/vars/Rocky/8.yml
+++ b/vars/Rocky/8.yml
@@ -15,5 +15,5 @@ additional_rpm_installs:
   - "@ruby:{{ ruby_version }}"
   - "@nodejs:{{ nodejs_version }}"
 
-repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/$basearch/'
-repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/SRPMS/'
+ood_repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/$basearch/'
+ood_repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el8/SRPMS/'

--- a/vars/Rocky/9.yml
+++ b/vars/Rocky/9.yml
@@ -16,3 +16,6 @@ additional_rpm_installs:
   - '@ruby:{{ ruby_version }}'
 
 rpm_repo_key: https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand-SHA512
+
+repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/$basearch/'
+repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/SRPMS/'

--- a/vars/Rocky/9.yml
+++ b/vars/Rocky/9.yml
@@ -17,5 +17,5 @@ additional_rpm_installs:
 
 rpm_repo_key: https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand-SHA512
 
-repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/$basearch/'
-repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/SRPMS/'
+ood_repo_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/$basearch/'
+ood_repo_src_base_url: 'https://yum.osc.edu/ondemand/4.0/web/el9/SRPMS/'

--- a/vars/Ubuntu/18.yml
+++ b/vars/Ubuntu/18.yml
@@ -25,3 +25,5 @@ nginx_root: "/opt/rh/ondemand/root"
 nginx_bin: "{{ nginx_root }}/sbin/nginx"
 nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
 locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"
+
+repo_base_url: https://apt.osc.edu/ondemand/4.0/web/apt

--- a/vars/Ubuntu/18.yml
+++ b/vars/Ubuntu/18.yml
@@ -26,4 +26,4 @@ nginx_bin: "{{ nginx_root }}/sbin/nginx"
 nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
 locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"
 
-repo_base_url: https://apt.osc.edu/ondemand/4.0/web/apt
+ood_repo_base_url: 'https://apt.osc.edu/ondemand/4.0/web/apt'

--- a/vars/Ubuntu/20.yml
+++ b/vars/Ubuntu/20.yml
@@ -27,3 +27,5 @@ nginx_root: "/opt/ood/ondemand/root"
 nginx_bin: "{{ nginx_root }}/usr/sbin/nginx"
 nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
 locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"
+
+repo_base_url: https://apt.osc.edu/ondemand/4.0/web/apt

--- a/vars/Ubuntu/20.yml
+++ b/vars/Ubuntu/20.yml
@@ -28,4 +28,4 @@ nginx_bin: "{{ nginx_root }}/usr/sbin/nginx"
 nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
 locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"
 
-repo_base_url: https://apt.osc.edu/ondemand/4.0/web/apt
+ood_repo_base_url: 'https://apt.osc.edu/ondemand/4.0/web/apt'

--- a/vars/Ubuntu/24.yml
+++ b/vars/Ubuntu/24.yml
@@ -27,3 +27,5 @@ nginx_root: "/opt/ood/ondemand/root"
 nginx_bin: "{{ nginx_root }}/usr/sbin/nginx"
 nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
 locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"
+
+repo_base_url: https://apt.osc.edu/ondemand/4.0/web/apt

--- a/vars/Ubuntu/24.yml
+++ b/vars/Ubuntu/24.yml
@@ -28,4 +28,4 @@ nginx_bin: "{{ nginx_root }}/usr/sbin/nginx"
 nginx_mime_types: "{{ nginx_root }}/etc/nginx/mime.types"
 locations_ini: "/opt/ood/ondemand/root/usr/share/ruby/vendor_ruby/phusion_passenger/locations.ini"
 
-repo_base_url: https://apt.osc.edu/ondemand/4.0/web/apt
+ood_repo_base_url: 'https://apt.osc.edu/ondemand/4.0/web/apt'


### PR DESCRIPTION
Allow users to manage repository files in this role.

While `ood_use_existing_repo_file` exists, that means that users need to manage that file outside of this role. Now with the config `dl_repo_package` users can manage this file within this role by supplying `repo_base_url` and `repo_src_base_url`. 